### PR TITLE
Fixed enum equals, will convert to underlying enum type before comparing...

### DIFF
--- a/src/DelegateDecompiler.Tests/DelegateDecompiler.Tests.csproj
+++ b/src/DelegateDecompiler.Tests/DelegateDecompiler.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="DecompileExtensionsTests.cs" />
     <Compile Include="DecompilerTestsBase.cs" />
     <Compile Include="Employee.cs" />
+    <Compile Include="EnumTests.cs" />
     <Compile Include="ListInitTests.cs" />
     <Compile Include="StringConcatTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/DelegateDecompiler.Tests/EnumTests.cs
+++ b/src/DelegateDecompiler.Tests/EnumTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace DelegateDecompiler.Tests
+{
+    public class EnumTests : DecompilerTestsBase
+    {
+        public enum TestEnum
+        {
+            Foo,
+            Bar
+        }
+
+        [Fact]
+        public void TestEnumParameterEqualsEnumConstant()
+        {
+            Expression<Func<TestEnum, bool>> expected = x => x == TestEnum.Bar;
+            Func<TestEnum, bool> compiled = x => x == TestEnum.Bar;
+            Test(expected, compiled);
+        }
+
+        [Fact]
+        public void TestEnumConstantEqualsEnumParameter()
+        {
+            Expression<Func<TestEnum, bool>> expected = x => TestEnum.Bar == x;
+            Func<TestEnum, bool> compiled = x => TestEnum.Bar == x;
+            Test(expected, compiled);
+        }
+    }
+}

--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -477,6 +477,9 @@ namespace DelegateDecompiler
                     var val1 = stack.Pop();
                     var val2 = stack.Pop();
 
+                    // Handle enum type comparison
+                    ConvertEnumExpressionToUnderlyingTypeForComparison(ref val1, ref val2);
+
                     stack.Push(Expression.Equal(val2, AdjustType(val1, val2.Type)));
                 }
                 else if (instruction.OpCode == OpCodes.Cgt || instruction.OpCode == OpCodes.Cgt_Un)
@@ -504,6 +507,14 @@ namespace DelegateDecompiler
             return stack.Count == 0
                        ? Expression.Empty()
                        : stack.Pop();
+        }
+
+        private void ConvertEnumExpressionToUnderlyingTypeForComparison(ref Expression val1, ref Expression val2)
+        {
+            if (val1.Type.IsEnum)
+                val1 = Expression.Convert(val1, val1.Type.GetEnumUnderlyingType());
+            if (val2.Type.IsEnum)
+                val2 = Expression.Convert(val2, val2.Type.GetEnumUnderlyingType());
         }
 
         static Expression Default(Type type)


### PR DESCRIPTION
Hi, I just started using your DelegateDecompiler project, and I think it's awesome!

While testing it I found out that comparing enum values did not work, so I created a small patch to fix that, along with tests. Do you think it looks ok?

Thanks :)
