### PR TITLE
Fixed some cases of enum comparison combined with branching.

### DIFF
--- a/src/DelegateDecompiler.Tests/EnumTests.cs
+++ b/src/DelegateDecompiler.Tests/EnumTests.cs
@@ -36,6 +36,25 @@ namespace DelegateDecompiler.Tests
             Test(expected, compiled);
         }
 
+        [Fact(Skip = "Need optimization")]
+        public void TestEnumPropertyNotEqualsFooOrElseEnumPropertyEqualsBar()
+        {
+            // Original expected expression:
+            // Expression<Func<TestEnum, bool>> expected = x => (x != TestEnum.Bar) || (x == TestEnum.Foo);
+            // Expected expression before optimization:
+            Expression<Func<TestEnum, bool>> expected = x => (x != TestEnum.Bar) ? true : (x == TestEnum.Foo);
+            Func<TestEnum, bool> compiled = x => (x != TestEnum.Bar) || (x == TestEnum.Foo);
+            Test(expected, compiled);
+        }
+
+        [Fact]
+        public void TestEnumPropertyEqualsFooOrElseEnumPropertyEqualsBar()
+        {
+            Expression<Func<TestEnum, bool>> expected = x => (x == TestEnum.Bar) || (x == TestEnum.Foo);
+            Func<TestEnum, bool> compiled = x => (x == TestEnum.Bar) || (x == TestEnum.Foo);
+            Test(expected, compiled);
+        }
+
         [Fact]
         public void TestEnumParametersEqual()
         {


### PR DESCRIPTION
Hi, I found a few more cases where enum comparison wouldn't work.
Specifically when combining them with branches.

(x == TestEnum.Bar) || (x == TestEnum.Foo) <= This example would fail

Have fixed the issue and added test.

:)
