### PR TITLE
Fixed handling of multiple ret opcodes in GetFlow.

### DIFF
--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -680,6 +680,10 @@ namespace DelegateDecompiler
             while (instruction != null)
             {
                 instructions.Push(instruction);
+
+                if (instruction.OpCode.FlowControl == FlowControl.Return)
+                    break;
+
                 if (instruction.OpCode.FlowControl == FlowControl.Branch)
                 {
                     instruction = (Instruction) instruction.Operand;


### PR DESCRIPTION
Hello..

I found out that the tests TestEnumPropertyEqualsFooOrElseEnumPropertyEqualsBar and TestEnumPropertyNotEqualsFooOrElseEnumPropertyEqualsBar would result in an ArgumentException when running with Release build active.

Seems like the generated IL with optimization had multiple returns, which made GetJoinPoint return wrong instruction:

```
     x => (x == TestEnum.Bar) || (x == TestEnum.Foo):

    [0] IL_0000: ldarg.0    
    [1] IL_0001: ldc.i4 2222    
    [2] IL_0006: beq.s IL_0011  
    [3] IL_0008: ldarg.0    
    [4] IL_0009: ldc.i4 1111    
    [5] IL_000e: ceq    
    [6] IL_0010: ret    
    [7] IL_0011: ldc.i4.1   
    [8] IL_0012: ret    
```

I think I've fixed it by making GetFlow break when seeing a ret opcode, but this should probably be verified. At least it makes all tests OK when running on Release build.
