### PR TITLE
Making ShouldDecompile virtual

### DIFF
--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -36,7 +36,7 @@ namespace DelegateDecompiler
             return base.VisitMethodCall(node);
         }
 
-        static bool ShouldDecompile(ICustomAttributeProvider methodInfo)
+        protected virtual bool ShouldDecompile(MemberInfo methodInfo)
         {
             return methodInfo.GetCustomAttributes(typeof (DecompileAttribute), true).Length > 0 ||
                    methodInfo.GetCustomAttributes(typeof (ComputedAttribute), true).Length > 0;


### PR DESCRIPTION
Making ShouldDecompile a virtual instance method, so one can override it
in a custom scenario.

For me it was needed to integrate it into DevExpress XPO Linq processing without using the special attibutes in my data layer project, probably it could be a useful usability improvements for others as well.
