### PR TITLE
Introduces an ExpressionVisitor to replace nullable ctors with Expressio...

### DIFF
--- a/src/DelegateDecompiler.Tests/NullTests.cs
+++ b/src/DelegateDecompiler.Tests/NullTests.cs
@@ -21,5 +21,13 @@ namespace DelegateDecompiler.Tests
             Func<string, bool> compiled = x => x.Equals(null);
             Test(expected, compiled);
         }
+
+        [Fact]
+        public void ExpressionWithNullable()
+        {
+            Expression<Func<int, int?>> expected = x => (int?)x;
+            Func<int, int?> compiled = x => (int?)x;
+            Test(expected, compiled);
+        }
     }
 }

--- a/src/DelegateDecompiler/DelegateDecompiler.csproj
+++ b/src/DelegateDecompiler/DelegateDecompiler.csproj
@@ -63,6 +63,7 @@
     <Compile Include="DecompileExtensions.cs" />
     <Compile Include="DefaultConfiguration.cs" />
     <Compile Include="MethodBodyDecompiler.cs" />
+    <Compile Include="NewNullableExpressionVisitor.cs" />
     <Compile Include="Processor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReplaceExpressionVisitor.cs" />

--- a/src/DelegateDecompiler/MethodBodyDecompiler.cs
+++ b/src/DelegateDecompiler/MethodBodyDecompiler.cs
@@ -35,8 +35,9 @@ namespace DelegateDecompiler
         {
             var instructions = method.GetInstructions();
             var ex = Processor.Create(locals, args).Process(instructions.First(), method.ReturnType);
-
-            return Expression.Lambda(ex, args);
+            LambdaExpression lambda = Expression.Lambda(ex, args);
+            lambda = (LambdaExpression)new NewNullableExpressionVisitor().Visit(lambda);
+            return lambda;
         }
     }
 }

--- a/src/DelegateDecompiler/NewNullableExpressionVisitor.cs
+++ b/src/DelegateDecompiler/NewNullableExpressionVisitor.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace DelegateDecompiler
+{
+    // Convert nullable constructors to a Convert call instead
+    public class NewNullableExpressionVisitor : ExpressionVisitor
+    {
+        protected override Expression VisitNew(NewExpression node)
+        {
+            // Test if this is a nullable type
+            if (node.Type.IsGenericType && node.Type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                return Expression.Convert(node.Arguments[0], node.Type);
+            }
+            return base.VisitNew(node);
+        }
+    }
+}


### PR DESCRIPTION
...n.Convert. This addresses #26. It may not be pretty, but it addresses both the simple test case and my much more complicated use cases in production code.
