### PR TITLE
Makes Address and Processor internal. Renames the EF-specific extension to DecompileAsync

### DIFF
--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.12.0.0 on Thursday, 11 December 2014 17:48
+## Documentation produced for DelegateDecompiler, version 0.12.0.0 on Friday, 12 December 2014 09:48
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.12.0.0 on Thursday, 11 December 2014 17:48
+## Documentation produced for DelegateDecompiler, version 0.12.0.0 on Friday, 12 December 2014 09:48
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.12.0.0 on Thursday, 11 December 2014 17:48
+## Documentation produced for DelegateDecompiler, version 0.12.0.0 on Friday, 12 December 2014 09:48
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test02SelectAsync.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test02SelectAsync.cs
@@ -28,7 +28,7 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
 
                 //ATTEMPT
                 env.AboutToUseDelegateDecompiler();
-                var dd = await env.Db.EfParents.Select(x => x.BoolEqualsConstant).Decompile().ToListAsync();
+                var dd = await env.Db.EfParents.Select(x => x.BoolEqualsConstant).DecompileAsync().ToListAsync();
 
                 //VERIFY
                 env.CompareAndLogList(linq, dd);
@@ -47,7 +47,7 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
 
                 //ATTEMPT
                 env.AboutToUseDelegateDecompiler();
-                var dd = await env.Db.EfParents.Select(x => x.BoolEqualsStaticVariable).Decompile().ToListAsync();
+                var dd = await env.Db.EfParents.Select(x => x.BoolEqualsStaticVariable).DecompileAsync().ToListAsync();
 
                 //VERIFY
                 env.CompareAndLogList(linq, dd);
@@ -64,7 +64,7 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
 
                 //ATTEMPT
                 env.AboutToUseDelegateDecompiler();
-                var dd = await env.Db.EfParents.Select(x => x.IntEqualsConstant).Decompile().ToListAsync();
+                var dd = await env.Db.EfParents.Select(x => x.IntEqualsConstant).DecompileAsync().ToListAsync();
 
                 //VERIFY
                 env.CompareAndLogList(linq, dd);

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test11SingleAsync.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test11SingleAsync.cs
@@ -33,7 +33,7 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
                 env.AboutToUseDelegateDecompiler();
                 var dd = (await
                     env.Db.EfParents.Select(x => new {x.EfParentId, x.IntEqualsUniqueValue})
-                        .Decompile()
+                        .DecompileAsync()
                         .SingleAsync(x => x.IntEqualsUniqueValue))
                         .EfParentId;
 

--- a/src/DelegateDecompiler.EntityFramework/DecompileExtensions.cs
+++ b/src/DelegateDecompiler.EntityFramework/DecompileExtensions.cs
@@ -13,7 +13,7 @@ namespace DelegateDecompiler.EntityFramework
     {
         private static readonly ConcurrentDictionary<MethodInfo, LambdaExpression> cache = new ConcurrentDictionary<MethodInfo, LambdaExpression>();
 
-        public static IQueryable<T> Decompile<T>(this IQueryable<T> self)
+        public static IQueryable<T> DecompileAsync<T>(this IQueryable<T> self)
         {
             var provider = new AsyncDecompiledQueryProvider(self.Provider);
             return provider.CreateQuery<T>(self.Expression);

--- a/src/DelegateDecompiler/Address.cs
+++ b/src/DelegateDecompiler/Address.cs
@@ -3,7 +3,7 @@ using System.Linq.Expressions;
 
 namespace DelegateDecompiler
 {
-    public class Address
+    class Address
     {
         public Expression Expression { get; set; }
 

--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -11,7 +11,7 @@ using System.Runtime.CompilerServices;
 
 namespace DelegateDecompiler
 {
-    public class Processor 
+    class Processor 
     {
         private const string cachedAnonymousMethodDelegate = "<>9__CachedAnonymousMethodDelegate";
 


### PR DESCRIPTION
RE #35. I renamed the extension to DecompileAsync to match the subsequent XYZAsync calls that are the whole point for having an alternate extension.

I also went ahead and made Address and Processor internal to avoid name clashes since those are pretty common names and there's really no need for them to be public.

Obviously feel free to go a different direction or reject the changes, just figured I would take a shot at it since these were pretty minor.
