### PR TITLE
Removing Recursion from Processor

### DIFF
--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 1.0.0.0 on Tuesday, 13 January 2015 11:04
+## Documentation produced for DelegateDecompiler, version 1.0.0.0 on Tuesday, 13 January 2015 14:26
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.12.1.0 on Monday, 15 December 2014 02:19
+## Documentation produced for DelegateDecompiler, version 1.0.0.0 on Tuesday, 13 January 2015 11:04
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.12.1.0 on Monday, 15 December 2014 02:19
+## Documentation produced for DelegateDecompiler, version 1.0.0.0 on Tuesday, 13 January 2015 11:04
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 1.0.0.0 on Tuesday, 13 January 2015 11:04
+## Documentation produced for DelegateDecompiler, version 1.0.0.0 on Tuesday, 13 January 2015 14:26
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.12.1.0 on Monday, 15 December 2014 02:19
+## Documentation produced for DelegateDecompiler, version 1.0.0.0 on Tuesday, 13 January 2015 11:04
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 1.0.0.0 on Tuesday, 13 January 2015 11:04
+## Documentation produced for DelegateDecompiler, version 1.0.0.0 on Tuesday, 13 January 2015 14:26
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).

--- a/src/DelegateDecompiler.Tests/DelegateDecompiler.Tests.csproj
+++ b/src/DelegateDecompiler.Tests/DelegateDecompiler.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="LambdaTests.cs" />
     <Compile Include="ListInitTests.cs" />
     <Compile Include="NullTests.cs" />
+    <Compile Include="StackOverflowTest.cs" />
     <Compile Include="StringConcatTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueryableExtensionsTests.cs" />

--- a/src/DelegateDecompiler.Tests/StackOverflowTest.cs
+++ b/src/DelegateDecompiler.Tests/StackOverflowTest.cs
@@ -59,7 +59,6 @@ namespace DelegateDecompiler.Tests
         [Test]
         public void StackOverflowTestOnThreadWithSmallStack()
         {
-            // Create a 256-byte maximum stack similar to new(ish) IIS defaults
             Thread thread = new Thread(() =>
             {
                 Expression<Func<Employee, string>> expected = e => e.FirstName != null ? e.FirstName :

--- a/src/DelegateDecompiler.Tests/StackOverflowTest.cs
+++ b/src/DelegateDecompiler.Tests/StackOverflowTest.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using NUnit.Framework;
+using System.Threading;
+
+namespace DelegateDecompiler.Tests
+{
+    [TestFixture]
+    public class StackOverflowTest : DecompilerTestsBase
+    {
+        [Test]
+        public void StackOverflowTestOnCurrentThread()
+        {
+            Expression<Func<Employee, string>> expected = e => e.FirstName != null ? e.FirstName :
+                (e.FirstName != null ? e.FirstName :
+                (e.FirstName != null ? e.FirstName :
+                (e.FirstName != null ? e.FirstName :
+                (e.FirstName != null ? e.FirstName :
+                (e.FirstName != null ? e.FirstName :
+                (e.FirstName != null ? e.FirstName : e.LastName))))));
+            Func<Employee, string> compiled = e => e.FirstName != null ? e.FirstName :
+                (e.FirstName != null ? e.FirstName :
+                (e.FirstName != null ? e.FirstName :
+                (e.FirstName != null ? e.FirstName :
+                (e.FirstName != null ? e.FirstName :
+                (e.FirstName != null ? e.FirstName :
+                (e.FirstName != null ? e.FirstName : e.LastName))))));
+            Test(expected, compiled);
+        }
+
+        [Test]
+        public void StackOverflowTestOnThreadWithLargeStack()
+        {
+            Thread thread = new Thread(() =>
+            {
+                Expression<Func<Employee, string>> expected = e => e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName : e.LastName))))));
+                Func<Employee, string> compiled = e => e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName : e.LastName))))));
+                Test(expected, compiled);
+            }, Int32.MaxValue);
+            thread.Start();
+            thread.Join();
+        }
+
+        [Test]
+        public void StackOverflowTestOnThreadWithSmallStack()
+        {
+            // Create a 256-byte maximum stack similar to new(ish) IIS defaults
+            Thread thread = new Thread(() =>
+            {
+                Expression<Func<Employee, string>> expected = e => e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName : e.LastName))))));
+                Func<Employee, string> compiled = e => e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName :
+                    (e.FirstName != null ? e.FirstName : e.LastName))))));
+                Test(expected, compiled);
+            }, 128);
+            thread.Start();
+            thread.Join();
+        }
+    }
+}

--- a/src/DelegateDecompiler/MethodBodyDecompiler.cs
+++ b/src/DelegateDecompiler/MethodBodyDecompiler.cs
@@ -38,7 +38,7 @@ namespace DelegateDecompiler
         public LambdaExpression Decompile()
         {
             var instructions = method.GetInstructions();
-            var ex = Processor.Create(locals, args).Process(instructions.First(), method.ReturnType);
+            var ex = Processor.Process(locals, args, instructions.First(), method.ReturnType);
             return Expression.Lambda(new OptimizeExpressionVisitor().Visit(ex), args.Select(x => (ParameterExpression) x.Expression));
         }
     }

--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -880,45 +880,6 @@ namespace DelegateDecompiler
             return joinPointState.Common;
         }
 
-        static Instruction GetCommon(IEnumerable<Instruction> leftFlow, Stack<Instruction> rightFlow)
-        {
-            Instruction instruction = null;
-            foreach (var left in leftFlow)
-            {
-                if (rightFlow.Count <= 0 || left != rightFlow.Pop())
-                    break;
-                
-                instruction = left;
-            }
-            return instruction;
-        }
-
-        static Stack<Instruction> GetFlow(Instruction instruction)
-        {
-            var instructions = new Stack<Instruction>();
-            while (instruction != null)
-            {
-                instructions.Push(instruction);
-
-                if (instruction.OpCode.FlowControl == FlowControl.Return)
-                    break;
-
-                if (instruction.OpCode.FlowControl == FlowControl.Branch)
-                {
-                    instruction = (Instruction) instruction.Operand;
-                }
-                else if (instruction.OpCode.FlowControl == FlowControl.Cond_Branch)
-                {
-                    instruction = GetJoinPoint((Instruction) instruction.Operand, instruction.Next);
-                }
-                else
-                {
-                    instruction = instruction.Next;
-                }
-            }
-            return instructions;
-        }
-
         static Expression AdjustType(Expression expression, Type type)
         {
             var constantExpression = expression as ConstantExpression;


### PR DESCRIPTION
This pull request requires a little explanation - sorry for the long-winded text that follows. 

Recall that I mentioned IIS was silently killing my worker process for a large-scale app on a particular complex query being run through DelegateDecompiler. I tracked the issue down to a stack overflow occurring during query execution, so I started looking for possible causes. Looking at `Processor` I found two potential sources of overflow due to recursion:

* `Processor.Process()` when called from `Processor.ConditionalBranch()` - this might be a problem with lots of nested conditionals (which my problem query has).
* `Processor.GetJoinPoint()` which uses recursion to find the common join point for nested conditional branches.

I formulated a test that uses a new thread with a limited stack size and deeply nested conditionals to trigger a stack overflow in a controlled manner, as expected. Then I removed the recursion in `Processor.Process()` by making `Processor` essentially stateless except for a single `Stack` that holds state information. Instead of recursion for conditional branches, `Processor` now iterates on the states in the `Stack`. I also used a similar strategy to remove recursion from `Processor.GetJoinPoint()` (which ended up looking a little inelegant, but it gets the job done). After applying these changes, my limited stack size tests passed.

Here's why this pull request requires explanation though - this didn't actually solve my underlying problem. Which these changes probably do reduce the likelihood of stack overflows in some situations, I discovered later that my own issue is caused by an infinite loop or deep recursion within `System.Data.Query.PlanCompiler` and `System.Data.Query.InternalTrees`. Something about my decompiled query just doesn't agree with Entity Framework, and at this point I'm more likely to think this is a bug in EF and not in DelegateDecompiler.

Regardless, the changes in this PR do result in passing the stack overflow test which failed before. I figured since the work was already done, I would see if you thought it was a good idea to merge them in.
