### PR TITLE
Support for if statements

### DIFF
--- a/src/DelegateDecompiler.Tests/ConditionalTests.cs
+++ b/src/DelegateDecompiler.Tests/ConditionalTests.cs
@@ -175,5 +175,54 @@ namespace DelegateDecompiler.Tests
             Func<Employee, string, bool> compiled = (u,term) => (u.FirstName != null && (u.FirstName.Contains(term) || term.Contains(u.FirstName))) && !u.IsBlocked;
             Test(expected, compiled);
         }
+
+        [Test]
+        public void SimpleIfStatement()
+        {
+            Expression<Func<int, int, int>> expected = (a, b) => a >= b ? b : a;
+            Func<int, int, int> compiled = (a, b) =>
+            {
+                var result = b;
+                if (a < b)
+                    result = a;
+                return result;
+            };
+            Test(expected, compiled);
+        }
+
+        [Test]
+        public void SimpleIfElseStatement()
+        {
+            Expression<Func<int, int, int>> expected = (a, b) => a >= b ? b : a;
+            Func<int, int, int> compiled = (a, b) =>
+            {
+                if (a < b)
+                    return a;
+                else
+                    return b;
+            };
+            Test(expected, compiled);
+        }
+
+        [Test]
+        public void IfElseStatementWithTwoLocalVariables()
+        {
+            Expression<Func<int, int, int>> expected = (a, b) => a + b + (a >= b ? 2 : 1) + 10;
+            Func<int, int, int> compiled = (a, b) =>
+            {
+                var c = 0;
+                var d = 10;
+                if (a < b)
+                {
+                    c = 1;
+                }
+                else
+                {
+                    c = 2;
+                }
+                return a + b + c + d;
+            };
+            Test(expected, compiled);
+        }
     }
 }

--- a/src/DelegateDecompiler/Address.cs
+++ b/src/DelegateDecompiler/Address.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace DelegateDecompiler
@@ -20,6 +21,38 @@ namespace DelegateDecompiler
         public static implicit operator Address(Expression expression)
         {
             return new Address {Expression = expression};
+        }
+
+        public Address Clone(IDictionary<Address, Address> map)
+        {
+            if (map.ContainsKey(this))
+                return map[this];
+            var result = new Address() { Expression = this.Expression };
+            map[this] = result;
+            return result;
+        }
+
+        public static Address Merge(Expression test, Address address1, Address address2,
+            IDictionary<Tuple<Address, Address>, Address> map)
+        {
+            var addresses = Tuple.Create(address1, address2);
+            if (map.ContainsKey(addresses))
+                return map[addresses];
+            Address result;
+            if (address1.Expression == address2.Expression)
+            {
+                result = address1;
+            }
+            else
+            {
+                var left = address1.Expression ?? Expression.Constant(null, address2.Type);
+                var right = address2.Expression ?? Expression.Constant(null, address1.Type);
+                left = Processor.AdjustType(left, right.Type);
+                right = Processor.AdjustType(right, left.Type);
+                result = Expression.Condition(test, left, right);
+            }
+            map[addresses] = result;
+            return result;
         }
     }
 }

--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -990,7 +990,9 @@ namespace DelegateDecompiler
             var mArgs = GetArguments(state, m);
 
             var instance = m.IsStatic ? new Address() : state.Stack.Pop();
-            state.Stack.Push(BuildMethodCallExpression(m, instance, mArgs));
+            var result = BuildMethodCallExpression(m, instance, mArgs);
+            if (m.ReturnType != typeof(void))
+                state.Stack.Push(result);
         }
 
         static Expression[] GetArguments(ProcessorState state, MethodBase m)

--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -24,9 +24,10 @@ namespace DelegateDecompiler
 
             public Instruction Instruction { get; set; }
 
-            public ProcessorState(Stack<Address> stack, VariableInfo[] locals, IList<Address> args, Instruction instruction, Instruction last = null)
+            public ProcessorState(Stack<Address> stack, VariableInfo[] locals, IList<Address> args, Instruction instruction,
+               Instruction last = null, IDictionary<FieldInfo, Address> delegates = null)
             {
-                Delegates = new Dictionary<FieldInfo, Address>();
+                Delegates = delegates ?? new Dictionary<FieldInfo, Address>();
                 Stack = stack;
                 Locals = locals;
                 Args = args;
@@ -36,7 +37,43 @@ namespace DelegateDecompiler
 
             public ProcessorState Clone(Instruction instruction, Instruction last = null)
             {
-                return new ProcessorState(new Stack<Address>(Stack), Locals.ToArray(), Args.ToArray(), instruction, last);
+                var state = new ProcessorState(null, new VariableInfo[Locals.Length], Args.ToArray(), instruction, last, Delegates);
+                var addressMap = new Dictionary<Address, Address>();
+                var buffer = new List<Address>();
+                foreach (var address in Stack)
+                {
+                    buffer.Add(address.Clone(addressMap));
+                }
+                state.Stack = new Stack<Address>(Enumerable.Reverse(buffer));
+                for (int i = 0; i < Locals.Length; i++)
+                {
+                    state.Locals[i] = new VariableInfo(Locals[i].Type);
+                    state.Locals[i].Address = Locals[i].Address.Clone(addressMap);
+                }
+                return state;
+            }
+
+            public void Merge(Expression test, ProcessorState leftState, ProcessorState rightState)
+            {
+                var addressMap = new Dictionary<Tuple<Address, Address>, Address>();
+                for (int i = 0; i < leftState.Locals.Length; i++)
+                {
+                    var leftLocal = leftState.Locals[i];
+                    var rightLocal = rightState.Locals[i];
+                    Locals[i].Address = Address.Merge(test, leftLocal.Address, rightLocal.Address, addressMap);
+                }
+                var buffer = new List<Address>();
+                while (leftState.Stack.Count > 0 || rightState.Stack.Count > 0)
+                {
+                    var rightExpression = rightState.Stack.Pop();
+                    var leftExpression = leftState.Stack.Pop();
+                    buffer.Add(Address.Merge(test, leftExpression, rightExpression, addressMap));
+                }
+                Stack.Clear();
+                foreach (var address in Enumerable.Reverse(buffer))
+                {
+                    Stack.Push(address);
+                }
             }
 
             public Expression Final()
@@ -768,16 +805,7 @@ namespace DelegateDecompiler
             states.Push(leftState);
 
             // Run this once the conditional branches have been processed
-            state.RunNext = () =>
-            {
-                var rightExpression = rightState.Final();
-                var leftExpression = leftState.Final();
-                leftExpression = AdjustType(leftExpression, rightExpression.Type);
-                rightExpression = AdjustType(rightExpression, leftExpression.Type);
-
-                var expression = Expression.Condition(test, leftExpression, rightExpression);
-                state.Stack.Push(expression);
-            };
+            state.RunNext = () => state.Merge(test, leftState, rightState);
 
             return common;
         }
@@ -880,7 +908,7 @@ namespace DelegateDecompiler
             return joinPointState.Common;
         }
 
-        static Expression AdjustType(Expression expression, Type type)
+        internal static Expression AdjustType(Expression expression, Type type)
         {
             var constantExpression = expression as ConstantExpression;
             if (constantExpression != null)


### PR DESCRIPTION
Hello Alexander,

I tried to decompile a simple function like
```c#
int Min(int a, int b)
{
   if (a < b)
      return a;
   else
      return b;
}
```
And it did not work. The reason is `Processor.ConditionalBranch` method is probably written in assumption that left and right states differ only by values on the top of their stacks. Although it is true for IL generated from ternary operator (`a < b ? a : b`), in case of if-else statement the states of the branches at the joint point may not differ by stacks (in the Min function above both stacks are empty at the joint point) but by locals. This issue could be solved by merging both stacks and locals (`ProcessorState.Merge`).

That leads to the modification of `ProcessorState.Clone` as current version only makes shallow copy of stack and locals, and modification of child states may lead to modification of parent state. 

When cloning parent state with two pointers to the same Address (for example, from stack and from local) clones of these pointers should also point to the same Address (but different from the parent Address). That is why dictionary is used at `Address.Clone` method.

When merging back such pointers the resulting pointers should still point to the same address (even if this address has different value for the left and right branches). Therefore `Address.Merge` also uses a dictionary.

That is basically all changes I made. 

There is also an unrelated change to `Processor.Call`, because current version pushes expressions of type void to stack, that are later ignored.

Thank you for you great work on DelegateDecompiler. 

I hope you would have time to consider these changes.