### PR TITLE
Failing EF test for adding nullable decimals

### DIFF
--- a/src/DelegateDecompiler.EntityFramework.Tests/EfItems/EfParent.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/EfItems/EfParent.cs
@@ -17,6 +17,10 @@ namespace DelegateDecompiler.EntityFramework.Tests.EfItems
 
         public int? ParentNullableInt { get; set; }
 
+        public decimal? ParentNullableDecimal1 { get; set; }
+
+        public decimal? ParentNullableDecimal2 { get; set; }
+
         public double ParentDouble { get; set; }
 
         public string ParentString { get; set; }
@@ -60,6 +64,9 @@ namespace DelegateDecompiler.EntityFramework.Tests.EfItems
 
         [Computed]
         public Nullable<int> NullableInit { get { return new Nullable<int>(); } }
+
+        [Computed]
+        public decimal? ParentNullableDecimalAdd { get { return ParentNullableDecimal1 + ParentNullableDecimal2; } }
 
         //EQUALITY GROUP
 

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test04Nullable.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test04Nullable.cs
@@ -7,6 +7,8 @@ using System;
 
 namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
 {
+    using System.Linq.Expressions;
+
     class Test04Nullable
     {
         private ClassEnvironment classEnv;
@@ -81,6 +83,23 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
                 //ATTEMPT
                 env.AboutToUseDelegateDecompiler();
                 var dd = env.Db.EfParents.Select(x => x.NullableInit).Decompile().ToList();
+
+                //VERIFY
+                env.CompareAndLogList(linq, dd);
+            }
+        }
+
+        [Test]
+        public void TestNullableAdd()
+        {
+            using (var env = new MethodEnvironment(classEnv))
+            {
+                //SETUP
+                var linq = env.Db.EfParents.Select(x => x.ParentNullableDecimal1 + x.ParentNullableDecimal2).ToList();
+
+                //ATTEMPT
+                env.AboutToUseDelegateDecompiler();
+                var dd = env.Db.EfParents.Select(x => x.ParentNullableDecimalAdd).Decompile().ToList();
 
                 //VERIFY
                 env.CompareAndLogList(linq, dd);


### PR DESCRIPTION
I ran into an issue in EF where a computed property w/ nullable decimals hit an exception "LINQ to Entities does not recognize the method 'System.Decimal GetValueOrDefault()' method, and this method cannot be translated into a store expression.". The EF version lifts the values to nulls when using Expression.Add. Or something.

This is just the failing test.