### PR TITLE
Solution of Compute - Include - Decompile problem

### DIFF
--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -12,6 +12,50 @@ namespace DelegateDecompiler
             return new DecompileExpressionVisitor().Visit(expression);
         }
 
+		private static readonly object NULL = new object(); // for use as a dictionary key
+		private readonly Dictionary<object, Expression> visitedConstants;
+
+		private bool hasAnyChanges = false;
+		public override Expression Visit(Expression node)
+		{
+			var result = base.Visit(node);
+			if (result != node)
+				hasAnyChanges = true;
+			return result;
+		}
+
+		private DecompileExpressionVisitor(Dictionary<object, Expression> sharedVisitedConstants = null)
+		{
+			this.visitedConstants = sharedVisitedConstants ?? new Dictionary<object, Expression>();
+		}
+
+		protected override Expression VisitConstant(ConstantExpression node)
+		{
+			Expression result;
+			if (visitedConstants.TryGetValue(node.Value ?? NULL, out result))
+			{
+				return result; // avoid infinite recursion
+			}
+
+			if (typeof(IQueryable).IsAssignableFrom(node.Type))
+			{
+				visitedConstants.Add(node.Value ?? NULL, node);
+
+				var value = (IQueryable)node.Value;
+				var childVisitor = new DecompileExpressionVisitor(visitedConstants);
+				result = childVisitor.Visit(value.Expression);
+
+				if (childVisitor.hasAnyChanges)
+				{
+					result = Expression.Constant(value.Provider.CreateQuery(result), node.Type);
+					visitedConstants[node.Value ?? NULL] = result;
+					return result;
+				}
+			}
+
+			return node;
+		}
+
         protected override Expression VisitMember(MemberExpression node)
         {
             if (ShouldDecompile(node.Member))


### PR DESCRIPTION
Issue https://github.com/hazzik/DelegateDecompiler/issues/52

Added `VisitConstant` method to `DecompileExpressionVisitor` class. If constant is `IQueryable` it value's expression should be visited.

Added some logic to avoid infinite recursion (because EF `DbSet` expression is a `value(ObjectQuery<...>).MergeAs(AppendData)` where first constant is a internal `DbSet` query itself with same expression in).

---

Добавил метод `VisitConstant` в класс `DecompileExpressionVisitor`. Если константа является `IQueryable` - выражение, хранящееся в ее значении, также будет преобразовано.

Также добавил логику, необходимую для того, чтобы избежать вечной рекурсии. Это необходимо, потому что выражение, содержащееся в `DbSet`, определяется как `value(ObjectQuery<...>).MergeAs(AppendData)`, где первая константа - это внутренний запрос самого `DbSet`, с точно таким же выражением внутри.
