### PR TITLE
Added support for property auto-setter

### DIFF
--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -276,7 +276,7 @@ namespace DelegateDecompiler
                             }
                             else
                             {
-                                throw new NotImplementedException();
+                                state.Stack.Push(Expression.Assign(Expression.Field(instance, field), value));
                             }
                         }
                     }
@@ -936,6 +936,10 @@ namespace DelegateDecompiler
             if (expression.Type == type)
             {
                 return expression;
+            }
+
+            if (type == typeof(void)) { 
+                return Expression.Block(expression, Expression.Empty());
             }
 
             var constantExpression = expression as ConstantExpression;


### PR DESCRIPTION
I'm using your code for walking a dependency hierarchy and need it for more than just expressions.  The code failed when trying to generate an expression for a property auto-setter, so this is a patch for this.

Looking at the code overall, it looks like you don't have support for statements in general, so I propose a feature branch for that.
