### PR TITLE
Fix for #51

### DIFF
--- a/src/DelegateDecompiler.EntityFramework/AsyncDecompiledQueryable.cs
+++ b/src/DelegateDecompiler.EntityFramework/AsyncDecompiledQueryable.cs
@@ -1,34 +1,9 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Data.Entity.Infrastructure;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DelegateDecompiler.EntityFramework
 {
-    class AsyncDecompiledQueryable : DecompiledQueryable, IDbAsyncEnumerable
-    {
-        private readonly IQueryable inner;
-
-        public AsyncDecompiledQueryable(IQueryProvider provider, IQueryable inner) : base(provider, inner)
-        {
-            this.inner = inner;
-        }
-
-        public IDbAsyncEnumerator GetAsyncEnumerator()
-        {
-            IDbAsyncEnumerable asyncEnumerable = inner as IDbAsyncEnumerable;
-            if (asyncEnumerable == null)
-            {
-                throw new InvalidOperationException("The source IQueryable doesn't implement IDbAsyncEnumerable.");
-            }
-            return asyncEnumerable.GetAsyncEnumerator();
-        }
-    }
-
     class AsyncDecompiledQueryable<T> : DecompiledQueryable<T>, IDbAsyncEnumerable<T>
     {
         private readonly IQueryable<T> inner;

--- a/src/DelegateDecompiler/DecompiledQueryProvider.cs
+++ b/src/DelegateDecompiler/DecompiledQueryProvider.cs
@@ -1,10 +1,17 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace DelegateDecompiler
 {
     public class DecompiledQueryProvider : IQueryProvider
     {
+        static readonly MethodInfo openGenericCreateQueryMethod =
+            typeof(DecompiledQueryProvider)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Single(method => method.Name == "CreateQuery" && method.IsGenericMethod);
         readonly IQueryProvider inner;
 
         protected internal DecompiledQueryProvider(IQueryProvider inner)
@@ -14,8 +21,20 @@ namespace DelegateDecompiler
 
         public virtual IQueryable CreateQuery(Expression expression)
         {
-            var decompiled = DecompileExpressionVisitor.Decompile(expression);
-            return new DecompiledQueryable(this, inner.CreateQuery(decompiled));
+            Type elementType = expression.Type
+                .GetInterfaces()
+                .Where(type => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                .Select(type => type.GetGenericArguments().FirstOrDefault())
+                .FirstOrDefault();
+
+            if (elementType == null)
+            {
+                throw new ArgumentException();
+            }
+
+            MethodInfo closedGenericCreateQueryMethod = openGenericCreateQueryMethod.MakeGenericMethod(elementType);
+
+            return (IQueryable)closedGenericCreateQueryMethod.Invoke(this, new object[] { expression });
         }
 
         public virtual IQueryable<TElement> CreateQuery<TElement>(Expression expression)

--- a/src/DelegateDecompiler/DecompiledQueryable.cs
+++ b/src/DelegateDecompiler/DecompiledQueryable.cs
@@ -6,16 +6,16 @@ using System.Linq.Expressions;
 
 namespace DelegateDecompiler
 {
-    public class DecompiledQueryable : IOrderedQueryable
+    public class DecompiledQueryable<T> : IOrderedQueryable<T>
     {
-        protected internal DecompiledQueryable(IQueryProvider provider, IQueryable inner)
+        private readonly IQueryable<T> inner;
+        private readonly IQueryProvider provider;
+
+        protected internal DecompiledQueryable(IQueryProvider provider, IQueryable<T> inner)
         {
             this.inner = inner;
             this.provider = provider;
         }
-
-        private readonly IQueryable inner;
-        private readonly IQueryProvider provider;
 
         public Expression Expression
         {
@@ -37,25 +37,14 @@ namespace DelegateDecompiler
             return inner.GetEnumerator();
         }
 
-        public override string ToString()
-        {
-            return inner.ToString();
-        }
-    }
-
-    public class DecompiledQueryable<T> : DecompiledQueryable, IOrderedQueryable<T>
-    {
-        private readonly IQueryable<T> inner;
-
-        protected internal DecompiledQueryable(IQueryProvider provider, IQueryable<T> inner)
-            : base(provider, inner)
-        {
-            this.inner = inner;
-        }
-
         public IEnumerator<T> GetEnumerator()
         {
             return inner.GetEnumerator();
+        }
+
+        public override string ToString()
+        {
+            return inner.ToString();
         }
     }
 }


### PR DESCRIPTION
The nongeneric `DecompiledQueryable` and `AsyncDecompiledQueryable` classes were deleted.
Work is delegated to the generic `CreateQuery<TElement>()` methods from the nongeneric ones in `DecompiledQueryProvider` and in `AsyncDecompiledQueryProvider`.

All classes that implement `IQueryable` should also implement `IQueryable<T>` and vice versa. The nongeneric `IQueryable` exists primarily to give you a weakly typed entry point primarily for dynamic query building scenarios. [source](https://blogs.msdn.microsoft.com/mattwar/2007/07/30/linq-building-an-iqueryable-provider-part-i/)
Entity Framework's query provider does the same work delegation. [source](https://github.com/aspnet/EntityFramework/blob/1fa247b038927a7d7438f666dc11253f64e0432d/src/Microsoft.EntityFrameworkCore/Query/Internal/EntityQueryProvider.cs)
This change also prevents the exceptions thrown by Microsoft's OData implementation when it tries to cast a compiled query to an `IQueryable<T>`