### PR TITLE
Resolution of virtual members

### DIFF
--- a/src/DelegateDecompiler.EntityFramework.Tests/App.config
+++ b/src/DelegateDecompiler.EntityFramework.Tests/App.config
@@ -16,6 +16,6 @@
     </providers>
   </entityFramework>
   <connectionStrings>
-    <add name="DelegateDecompilerEfTestDb" connectionString="Initial Catalog=DelegateDecompilerEfTestDb;MultipleActiveResultSets=True;Trusted_Connection=True;Data Source=.\SQLEXPRESS;Integrated Security=False;User ID=utilisateurweb;Password=root4EVER2015;Connect Timeout=15;Encrypt=False;" providerName="System.Data.SqlClient" />
+    <add name="DelegateDecompilerEfTestDb" connectionString="Data Source=.;Initial Catalog=DelegateDecompilerEfTestDb;MultipleActiveResultSets=True;Trusted_Connection=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
 </configuration>

--- a/src/DelegateDecompiler.EntityFramework.Tests/App.config
+++ b/src/DelegateDecompiler.EntityFramework.Tests/App.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    
+
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-  <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+  </configSections>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>
@@ -15,6 +16,6 @@
     </providers>
   </entityFramework>
   <connectionStrings>
-    <add name="DelegateDecompilerEfTestDb" connectionString="Data Source=.;Initial Catalog=DelegateDecompilerEfTestDb;MultipleActiveResultSets=True;Trusted_Connection=True" providerName="System.Data.SqlClient" />
+    <add name="DelegateDecompilerEfTestDb" connectionString="Initial Catalog=DelegateDecompilerEfTestDb;MultipleActiveResultSets=True;Trusted_Connection=True;Data Source=.\SQLEXPRESS;Integrated Security=False;User ID=utilisateurweb;Password=root4EVER2015;Connect Timeout=15;Encrypt=False;" providerName="System.Data.SqlClient" />
   </connectionStrings>
 </configuration>

--- a/src/DelegateDecompiler.EntityFramework.Tests/App.config
+++ b/src/DelegateDecompiler.EntityFramework.Tests/App.config
@@ -16,6 +16,6 @@
     </providers>
   </entityFramework>
   <connectionStrings>
-    <add name="DelegateDecompilerEfTestDb" connectionString="Data Source=.;Initial Catalog=DelegateDecompilerEfTestDb;MultipleActiveResultSets=True;Trusted_Connection=True" providerName="System.Data.SqlClient" />
+    <add name="DelegateDecompilerEfTestDb" connectionString="Initial Catalog=DelegateDecompilerEfTestDb;MultipleActiveResultSets=True;Trusted_Connection=True;Data Source=.\SQLEXPRESS;Integrated Security=False;User ID=utilisateurweb;Password=root4EVER2015;Connect Timeout=15;Encrypt=False;" providerName="System.Data.SqlClient" />
   </connectionStrings>
 </configuration>

--- a/src/DelegateDecompiler.EntityFramework.Tests/DelegateDecompiler.EntityFramework.Tests.csproj
+++ b/src/DelegateDecompiler.EntityFramework.Tests/DelegateDecompiler.EntityFramework.Tests.csproj
@@ -6,13 +6,13 @@
     <Copyright>Copyright © Dave Glick 2014, Jon Smith 2014, Alexander Zaytsev 2014 - 2017</Copyright>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="nunit" Version="3.7.1" />
+  <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.23.1 on Monday, 18 December 2017 13:13
+## Documentation produced for DelegateDecompiler, version 0.23.1 on Monday, 18 December 2017 15:06
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.23.1 on Tuesday, 14 March 2017 10:50
+## Documentation produced for DelegateDecompiler, version 0.23.1 on Monday, 18 December 2017 13:13
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.23.0 on Tuesday, 14 March 2017 10:50
+## Documentation produced for DelegateDecompiler, version 0.23.1 on Monday, 18 December 2017 13:13
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).
@@ -357,7 +357,7 @@ SELECT
             WHERE [Extent1].[EfParentId] = [Extent2].[EfParentId]) AS [C1]
         FROM [dbo].[EfParents] AS [Extent1]
     )  AS [Project1]
-    ORDER BY [Project1].[C1] ASC
+    ORDER BY row_number() OVER (ORDER BY [Project1].[C1] ASC)
     OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY 
 ```
 
@@ -380,7 +380,7 @@ SELECT
             WHERE [Extent1].[EfParentId] = [Extent2].[EfParentId]
         )
     )  AS [Project2]
-    ORDER BY [Project2].[C1] ASC
+    ORDER BY row_number() OVER (ORDER BY [Project2].[C1] ASC)
     OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY 
 ```
 

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.23.1 on Monday, 18 December 2017 13:13
+## Documentation produced for DelegateDecompiler, version 0.23.1 on Monday, 18 December 2017 15:06
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).
@@ -357,7 +357,7 @@ SELECT
             WHERE [Extent1].[EfParentId] = [Extent2].[EfParentId]) AS [C1]
         FROM [dbo].[EfParents] AS [Extent1]
     )  AS [Project1]
-    ORDER BY row_number() OVER (ORDER BY [Project1].[C1] ASC)
+    ORDER BY [Project1].[C1] ASC
     OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY 
 ```
 
@@ -380,7 +380,7 @@ SELECT
             WHERE [Extent1].[EfParentId] = [Extent2].[EfParentId]
         )
     )  AS [Project2]
-    ORDER BY row_number() OVER (ORDER BY [Project2].[C1] ASC)
+    ORDER BY [Project2].[C1] ASC
     OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY 
 ```
 

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.23.1 on Monday, 18 December 2017 13:13
+## Documentation produced for DelegateDecompiler, version 0.23.1 on Monday, 18 December 2017 15:06
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.23.1 on Tuesday, 14 March 2017 10:50
+## Documentation produced for DelegateDecompiler, version 0.23.1 on Monday, 18 December 2017 13:13
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).

--- a/src/DelegateDecompiler.EntityFramework/DelegateDecompiler.EntityFramework.csproj
+++ b/src/DelegateDecompiler.EntityFramework/DelegateDecompiler.EntityFramework.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.1.3" />
+    <PackageReference Include="EntityFramework" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DelegateDecompiler.EntityFramework/DelegateDecompiler.EntityFramework.csproj
+++ b/src/DelegateDecompiler.EntityFramework/DelegateDecompiler.EntityFramework.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DelegateDecompiler.Tests.VB/DelegateDecompiler.Tests.VB.vbproj
+++ b/src/DelegateDecompiler.Tests.VB/DelegateDecompiler.Tests.VB.vbproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\DelegateDecompiler.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net40</TargetFramework>
     <Copyright>Copyright © Alexander Zaytsev 2016 - 2017</Copyright>
     <Description />
   </PropertyGroup>

--- a/src/DelegateDecompiler.Tests.VB/DelegateDecompiler.Tests.VB.vbproj
+++ b/src/DelegateDecompiler.Tests.VB/DelegateDecompiler.Tests.VB.vbproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\DelegateDecompiler.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <Copyright>Copyright © Alexander Zaytsev 2016 - 2017</Copyright>
     <Description />
   </PropertyGroup>

--- a/src/DelegateDecompiler.Tests.VB/DelegateDecompiler.Tests.VB.vbproj
+++ b/src/DelegateDecompiler.Tests.VB/DelegateDecompiler.Tests.VB.vbproj
@@ -2,18 +2,19 @@
   <Import Project="..\..\DelegateDecompiler.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <Copyright>Copyright © Alexander Zaytsev 2016 - 2017</Copyright>
     <Description />
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="nunit" Version="3.7.1" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DelegateDecompiler.Tests/DelegateDecompiler.Tests.csproj
+++ b/src/DelegateDecompiler.Tests/DelegateDecompiler.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\DelegateDecompiler.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net40</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net40'">

--- a/src/DelegateDecompiler.Tests/DelegateDecompiler.Tests.csproj
+++ b/src/DelegateDecompiler.Tests/DelegateDecompiler.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\DelegateDecompiler.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net40'">

--- a/src/DelegateDecompiler.Tests/DelegateDecompiler.Tests.csproj
+++ b/src/DelegateDecompiler.Tests/DelegateDecompiler.Tests.csproj
@@ -2,16 +2,17 @@
   <Import Project="..\..\DelegateDecompiler.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="nunit" Version="3.7.1" />
-  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DelegateDecompiler.Tests/Issue113.cs
+++ b/src/DelegateDecompiler.Tests/Issue113.cs
@@ -1,0 +1,43 @@
+﻿using NUnit.Framework;
+using System;
+using System.Linq.Expressions;
+
+namespace DelegateDecompiler.Tests
+{
+    [TestFixture]
+    public class Issue113 : DecompilerTestsBase
+    {
+        private abstract class BaseClass
+        {
+            public int Property { get; set; }
+
+            [Computed]
+            public virtual int GetTotal()
+            {
+                return Property;
+            }
+        }
+
+        private class ConcreteClass
+            : BaseClass
+        {
+            public int OtherProperty { get; set; }
+
+            [Computed]
+            public override int GetTotal()
+            {
+                return base.GetTotal() + OtherProperty;
+            }
+        }
+
+        [Test]
+        public void DecompileOveriddenMemberWithBaseCall()
+        {
+            Expression<Func<ConcreteClass, int>> expected = x => x.Property + x.OtherProperty;
+            Expression<Func<ConcreteClass, int>> compiled = x => x.GetTotal();
+            var result = DecompileExpressionVisitor.Decompile(compiled);
+            Assert.AreEqual(expected.ToString(), result.ToString());
+            //Test(expected, compiled);
+        }
+    }
+}

--- a/src/DelegateDecompiler.Tests/Issue113.cs
+++ b/src/DelegateDecompiler.Tests/Issue113.cs
@@ -18,7 +18,7 @@ namespace DelegateDecompiler.Tests
             }
         }
 
-        private class ConcreteClass
+        private class ConcreteClass1
             : BaseClass
         {
             public int OtherProperty { get; set; }
@@ -30,14 +30,37 @@ namespace DelegateDecompiler.Tests
             }
         }
 
+        private class ConcreteClass2
+            : ConcreteClass1
+        {
+            [Computed]
+            public override int GetTotal()
+            {
+                return base.GetTotal() + 5;
+            }
+        }
+
+        private class ConcreteClass3_NotOverridden
+            : BaseClass
+        {
+        }
+
         [Test]
         public void DecompileOveriddenMemberWithBaseCall()
         {
-            Expression<Func<ConcreteClass, int>> expected = x => x.Property + x.OtherProperty;
-            Expression<Func<ConcreteClass, int>> compiled = x => x.GetTotal();
-            var result = DecompileExpressionVisitor.Decompile(compiled);
+            Expression<Func<ConcreteClass1, int>> expected = x => x is ConcreteClass2 ? (x as ConcreteClass2).Property + (x as ConcreteClass2).OtherProperty + 5 : x.Property + x.OtherProperty;
+            Expression<Func<ConcreteClass1, int>> compiled = x => x.GetTotal();
+            var result = new OptimizeExpressionVisitor().Visit(DecompileExpressionVisitor.Decompile(compiled));
             Assert.AreEqual(expected.ToString(), result.ToString());
-            //Test(expected, compiled);
+        }
+
+        [Test]
+        public void DecompileOveriddenMemberWithFullTypeHierarchy()
+        {
+            Expression<Func<BaseClass, int>> expected = x => x is ConcreteClass2 ? (x as ConcreteClass2).Property + (x as ConcreteClass2).OtherProperty + 5 : x is ConcreteClass1 ? (x as ConcreteClass1).Property + (x as ConcreteClass1).OtherProperty : x.Property;
+            Expression<Func<BaseClass, int>> compiled = x => x.GetTotal();
+            var result = new OptimizeExpressionVisitor().Visit(DecompileExpressionVisitor.Decompile(compiled));
+            Assert.AreEqual(expected.ToString(), result.ToString());
         }
     }
 }

--- a/src/DelegateDecompiler.Tests/Issue113.cs
+++ b/src/DelegateDecompiler.Tests/Issue113.cs
@@ -7,7 +7,7 @@ namespace DelegateDecompiler.Tests
     [TestFixture]
     public class Issue113 : DecompilerTestsBase
     {
-        private abstract class BaseClass
+        public abstract class BaseClass
         {
             public int Property { get; set; }
 
@@ -15,7 +15,7 @@ namespace DelegateDecompiler.Tests
             public abstract int GetTotal();
         }
 
-        private class ConcreteClassBase
+        public class ConcreteClassBase
             : BaseClass
         {
             [Computed]
@@ -25,7 +25,7 @@ namespace DelegateDecompiler.Tests
             }
         }
 
-        private class ConcreteClass1
+        public class ConcreteClass1
             : ConcreteClassBase
         {
             public int OtherProperty { get; set; }
@@ -37,7 +37,7 @@ namespace DelegateDecompiler.Tests
             }
         }
 
-        private class ConcreteClass2
+        public class ConcreteClass2
             : ConcreteClass1
         {
             [Computed]
@@ -47,12 +47,12 @@ namespace DelegateDecompiler.Tests
             }
         }
 
-        private class ConcreteClass3_NotOverridden
+        public class ConcreteClass3_NotOverridden
             : ConcreteClassBase
         {
         }
 
-        private class ConcreteClass4_OverrideWithGap
+        public class ConcreteClass4_OverrideWithGap
         : ConcreteClass3_NotOverridden
         {
             [Computed]

--- a/src/DelegateDecompiler.Tests/Issue113.cs
+++ b/src/DelegateDecompiler.Tests/Issue113.cs
@@ -84,9 +84,9 @@ namespace DelegateDecompiler.Tests
         public void DecompileOveriddenMemberWithFullTypeHierarchy()
         {
             Expression<Func<BaseClass, int>> expected =
-                x => x is ConcreteClass2 ? (x as ConcreteClass2).Property + (x as ConcreteClass2).OtherProperty + 5
+                x => x is ConcreteClass4_OverrideWithGap ? (x as ConcreteClass4_OverrideWithGap).Property * 2
+                    : x is ConcreteClass2 ? (x as ConcreteClass2).Property + (x as ConcreteClass2).OtherProperty + 5
                     : x is ConcreteClass1 ? (x as ConcreteClass1).Property + (x as ConcreteClass1).OtherProperty
-                    : x is ConcreteClass4_OverrideWithGap ? (x as ConcreteClass4_OverrideWithGap).Property * 2
                     : (x as ConcreteClassBase).Property;
             Expression<Func<BaseClass, int>> compiled = x => x.GetTotal();
             var result = new OptimizeExpressionVisitor().Visit(DecompileExpressionVisitor.Decompile(compiled));

--- a/src/DelegateDecompiler.Tests/Issue113.cs
+++ b/src/DelegateDecompiler.Tests/Issue113.cs
@@ -12,14 +12,21 @@ namespace DelegateDecompiler.Tests
             public int Property { get; set; }
 
             [Computed]
-            public virtual int GetTotal()
+            public abstract int GetTotal();
+        }
+
+        private class ConcreteClassBase
+            : BaseClass
+        {
+            [Computed]
+            public override int GetTotal()
             {
                 return Property;
             }
         }
 
         private class ConcreteClass1
-            : BaseClass
+            : ConcreteClassBase
         {
             public int OtherProperty { get; set; }
 
@@ -41,7 +48,7 @@ namespace DelegateDecompiler.Tests
         }
 
         private class ConcreteClass3_NotOverridden
-            : BaseClass
+            : ConcreteClassBase
         {
         }
 
@@ -57,7 +64,7 @@ namespace DelegateDecompiler.Tests
         [Test]
         public void DecompileOveriddenMemberWithFullTypeHierarchy()
         {
-            Expression<Func<BaseClass, int>> expected = x => x is ConcreteClass2 ? (x as ConcreteClass2).Property + (x as ConcreteClass2).OtherProperty + 5 : x is ConcreteClass1 ? (x as ConcreteClass1).Property + (x as ConcreteClass1).OtherProperty : x.Property;
+            Expression<Func<BaseClass, int>> expected = x => x is ConcreteClass2 ? (x as ConcreteClass2).Property + (x as ConcreteClass2).OtherProperty + 5 : x is ConcreteClass1 ? (x as ConcreteClass1).Property + (x as ConcreteClass1).OtherProperty : (x as ConcreteClassBase).Property;
             Expression<Func<BaseClass, int>> compiled = x => x.GetTotal();
             var result = new OptimizeExpressionVisitor().Visit(DecompileExpressionVisitor.Decompile(compiled));
             Assert.AreEqual(expected.ToString(), result.ToString());

--- a/src/DelegateDecompiler/Address.cs
+++ b/src/DelegateDecompiler/Address.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 
 namespace DelegateDecompiler
 {
-    class Address
+    internal class Address
     {
         public Expression Expression { get; set; }
 
@@ -20,7 +20,7 @@ namespace DelegateDecompiler
 
         public static implicit operator Address(Expression expression)
         {
-            return new Address {Expression = expression};
+            return new Address { Expression = expression };
         }
 
         public Address Clone(IDictionary<Address, Address> map)
@@ -49,6 +49,14 @@ namespace DelegateDecompiler
                 var right = address2.Expression ?? Expression.Default(address1.Type);
                 left = Processor.AdjustType(left, right.Type);
                 right = Processor.AdjustType(right, left.Type);
+                if (left.Type.IsSubclassOf(right.Type))
+                {
+                    left = Expression.Convert(left, right.Type);
+                }
+                else if (right.Type.IsSubclassOf(left.Type))
+                {
+                    right = Expression.Convert(right, left.Type);
+                }
                 result = Expression.Condition(test, left, right);
             }
             map[addresses] = result;

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 namespace DelegateDecompiler
 {
-    //TODO minor optimisation : remove explicit TypeAs expressions when redondant with the MemberInfo declaring type
+    //TODO minor optimisation : remove explicit TypeAs expressions when redondant with the MemberInfo declaring type ?
     public class DecompileExpressionVisitor : ExpressionVisitor
     {
         public static Expression Decompile(Expression expression)
@@ -50,7 +50,7 @@ namespace DelegateDecompiler
                     if (implementations is IEnumerable)
                     {
                         Expression expandedCall = null;
-                        var applicableCalls = (implementations as List<KeyValuePair<Type, MethodInfo>>).Where(vCall => vCall.Key == node.Object.Type || vCall.Key.IsSubclassOf(node.Object.Type)).GroupBy(kv => kv.Key);
+                        var applicableCalls = (implementations as List<KeyValuePair<Type, MethodInfo>>).Where(vCall => node.Object.Type.IsAssignableFrom(vCall.Key)).GroupBy(kv => kv.Key);
                         if (applicableCalls.Any())
                         {
                             bool handleObjectAsSubType = false;
@@ -169,8 +169,8 @@ namespace DelegateDecompiler
             var implementationsList = new List<KeyValuePair<Type, MethodInfo>>();
             bool shouldDecompile = ShouldDecompile(method);
             if (!method.IsAbstract) implementationsList.Add(new KeyValuePair<Type, MethodInfo>(method.DeclaringType, method));
-            var subclasses = AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic).SelectMany(a => a.GetExportedTypes().Where(t => t.IsSubclassOf(method.DeclaringType))).Where(t => t != null).ToList();
-            subclasses.Sort((t1, t2) => t1 == null || t2 == null ? 0 : t1.IsSubclassOf(t2) ? 1 : -1);
+            var subclasses = AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic).SelectMany(a => a.GetExportedTypes().Where(t => method.DeclaringType.IsAssignableFrom(t))).Where(t => t != null).ToList();
+            subclasses.Sort((t1, t2) => t1 == null || t2 == null ? 0 : t2.IsAssignableFrom(t1) ? 1 : -1);
             foreach (var c in subclasses)
             {
                 MethodInfo impl = c.GetMethod(method.Name, method.GetParameters().Select(a => a.ParameterType).ToArray());

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 
 namespace DelegateDecompiler
 {
+    //TODO minor optimisation : remove explicit TypeAs expressions when redondant with the MemberInfo declaring type
     public class DecompileExpressionVisitor : ExpressionVisitor
     {
         public static Expression Decompile(Expression expression)

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -170,11 +170,11 @@ namespace DelegateDecompiler
             var implementationsList = new List<KeyValuePair<Type, MethodInfo>>();
             implementationsList.Add(new KeyValuePair<Type, MethodInfo>(method.DeclaringType, method));
             var subclasses = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes().Where(t => t.IsSubclassOf(method.DeclaringType))).Where(t => t != null).ToList();
-            subclasses.Sort((t1, t2) => t1 == null || t2 == null ? 0 : t1.IsSubclassOf(t2) ? 1 : -1);
+            subclasses.Sort((t1, t2) => t1.IsSubclassOf(t2) ? 1 : -1);
             foreach (var c in subclasses)
             {
-                MethodInfo impl = c.GetMethod(method.Name, method.GetParameters()?.Select(a => a.ParameterType).ToArray());
-                if (impl?.DeclaringType == c)
+                MethodInfo impl = c.GetMethod(method.Name, method.GetParameters().Select(a => a.ParameterType).ToArray());
+                if (impl.DeclaringType == c)
                 {
                     if (impl.IsGenericMethod)
                     {

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -59,7 +59,6 @@ namespace DelegateDecompiler
                             bool requiresConditional = false;
                             if (mostSpecificImplementation != null)
                             {
-                                //var targetInstance = node.Object.Type == mostSpecificImplementation.DeclaringType ? node.Object : Expression.TypeAs(instance, mostSpecificImplementation.DeclaringType);
                                 var targetInstance = mostSpecificImplementation.DeclaringType.IsAssignableFrom(node.Object.Type) ? node.Object : Expression.TypeAs(instance, mostSpecificImplementation.DeclaringType);
                                 castObjects.Add(targetInstance);
                                 _virtualCallContexts.Add(new Tuple<Expression, MethodInfo>(targetInstance, mostSpecificImplementation));
@@ -173,7 +172,7 @@ namespace DelegateDecompiler
             bool shouldDecompile = ShouldDecompile(method);
             if (!method.IsAbstract) implementationsList.Add(new KeyValuePair<Type, MethodInfo>(method.DeclaringType, method));
             var subclasses = AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic).SelectMany(a => a.GetTypes().Where(t => t.IsSubclassOf(method.DeclaringType))).Where(t => t != null).ToList();
-            subclasses.Sort((t1, t2) => t1 == null || t2 == null ? 0 : t1.IsSubclassOf(t2) ? 1 : -1);
+            subclasses.Sort((t1, t2) => t1 == null || t2 == null ? 0 : t1.IsSubclassOf(t2) ? 1 : t1.FullName.CompareTo(t2.FullName));
             foreach (var c in subclasses)
             {
                 MethodInfo impl = c.GetMethod(method.Name, method.GetParameters().Select(a => a.ParameterType).ToArray());

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -170,11 +170,11 @@ namespace DelegateDecompiler
             var implementationsList = new List<KeyValuePair<Type, MethodInfo>>();
             implementationsList.Add(new KeyValuePair<Type, MethodInfo>(method.DeclaringType, method));
             var subclasses = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes().Where(t => t.IsSubclassOf(method.DeclaringType))).ToList();
-            subclasses.Sort((t1, t2) => t1.IsSubclassOf(t2) ? 1 : -1);
+            subclasses.Sort((t1, t2) => t1 == null || t2 == null ? 0 : t1.IsSubclassOf(t2) ? 1 : -1);
             subclasses.ForEach(c =>
             {
-                MethodInfo impl = c.GetMethod(method.Name, method.GetParameters().Select(a => a.ParameterType).ToArray());
-                if (impl.DeclaringType == c)
+                MethodInfo impl = c.GetMethod(method.Name, method.GetParameters()?.Select(a => a.ParameterType).ToArray());
+                if (impl?.DeclaringType == c)
                 {
                     if (impl.IsGenericMethod)
                     {

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -171,7 +171,7 @@ namespace DelegateDecompiler
             var implementationsList = new List<KeyValuePair<Type, MethodInfo>>();
             bool shouldDecompile = ShouldDecompile(method);
             if (!method.IsAbstract) implementationsList.Add(new KeyValuePair<Type, MethodInfo>(method.DeclaringType, method));
-            var subclasses = AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic).SelectMany(a => a.GetTypes().Where(t => t.IsSubclassOf(method.DeclaringType))).Where(t => t != null).ToList();
+            var subclasses = AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic).SelectMany(a => a.GetExportedTypes().Where(t => t.IsSubclassOf(method.DeclaringType))).Where(t => t != null).ToList();
             subclasses.Sort((t1, t2) => t1 == null || t2 == null ? 0 : t1.IsSubclassOf(t2) ? 1 : t1.FullName.CompareTo(t2.FullName));
             foreach (var c in subclasses)
             {

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -170,7 +170,7 @@ namespace DelegateDecompiler
             var implementationsList = new List<KeyValuePair<Type, MethodInfo>>();
             implementationsList.Add(new KeyValuePair<Type, MethodInfo>(method.DeclaringType, method));
             var subclasses = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes().Where(t => t.IsSubclassOf(method.DeclaringType))).Where(t => t != null).ToList();
-            subclasses.Sort((t1, t2) => t1.IsSubclassOf(t2) ? 1 : -1);
+            subclasses.Sort((t1, t2) => t1 == null || t2 == null ? 0 : t1.IsSubclassOf(t2) ? 1 : -1);
             foreach (var c in subclasses)
             {
                 MethodInfo impl = c.GetMethod(method.Name, method.GetParameters().Select(a => a.ParameterType).ToArray());

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -52,6 +52,7 @@ namespace DelegateDecompiler
                     {
                         Expression expandedCall = null;
                         mostSpecificImplementation = (implementations as List<KeyValuePair<Type, MethodInfo>>).Where(vCall => vCall.Key.IsAssignableFrom(node.Object.Type)).Select(kv => kv.Value).LastOrDefault();
+                        if (mostSpecificImplementation == null) return node;
 
                         var overridingImplementations = (implementations as List<KeyValuePair<Type, MethodInfo>>).Where(vCall => vCall.Key.IsSubclassOf(node.Object.Type)).GroupBy(kv => kv.Key);
                         if (overridingImplementations.Any())

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -162,7 +162,7 @@ namespace DelegateDecompiler
             var implementationsList = new List<KeyValuePair<Type, MethodInfo>>();
             bool shouldDecompile = ShouldDecompile(method);
             if (!method.IsAbstract) implementationsList.Add(new KeyValuePair<Type, MethodInfo>(method.DeclaringType, method));
-            var subclasses = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes().Where(t => t.IsSubclassOf(method.DeclaringType))).Where(t => t != null).ToList();
+            var subclasses = AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic).SelectMany(a => a.GetExportedTypes().Where(t => t.IsSubclassOf(method.DeclaringType))).Where(t => t != null).ToList();
             subclasses.Sort((t1, t2) => t1 == null || t2 == null ? 0 : t1.IsSubclassOf(t2) ? 1 : -1);
             foreach (var c in subclasses)
             {

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -171,7 +171,7 @@ namespace DelegateDecompiler
             implementationsList.Add(new KeyValuePair<Type, MethodInfo>(method.DeclaringType, method));
             var subclasses = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes().Where(t => t.IsSubclassOf(method.DeclaringType))).ToList();
             subclasses.Sort((t1, t2) => t1.IsSubclassOf(t2) ? 1 : -1);
-            subclasses.ForEach(c =>
+            foreach (var c in subclasses)
             {
                 MethodInfo impl = c.GetMethod(method.Name, method.GetParameters()?.Select(a => a.ParameterType).ToArray());
                 if (impl?.DeclaringType == c)
@@ -182,7 +182,7 @@ namespace DelegateDecompiler
                     }
                     implementationsList.Add(new KeyValuePair<Type, MethodInfo>(c, impl));
                 }
-            });
+            };
             _specificImplementations[method] = implementationsList;
             return implementationsList;
         }

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -28,34 +27,86 @@ namespace DelegateDecompiler
             return base.VisitMember(node);
         }
 
+        private Dictionary<Tuple<Expression, string>, Type> _methodInheritanceContext = new Dictionary<Tuple<Expression, string>, Type>();
+
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
-            if (node.Method.IsGenericMethod && node.Method.GetGenericMethodDefinition() == typeof (ComputedExtension).GetMethod("Computed", BindingFlags.Static | BindingFlags.Public))
-            {
-                var argument = node.Arguments.SingleOrDefault();
+            // PROBLEM - the MethodCallExpression does not always (?never?) point to the most
+            // specific method for the object when a Computed method is overriden
 
-                var member = argument as MemberExpression;
-                if (member != null)
+            Expression instanceParameter = node.Object;
+            //Allows to decompile overriding implementations of a Computed method
+            bool shouldDecompileOverriddenCall = false;
+            try
+            {
+                // WORKAROUND - find the most specific implementation not used for the parameter and
+                // redirects the call the base implementation when the method is called again in the
+                // same decompilation unit
+
+                // Side Effect => this makes it impossible to use recursive calls but those would
+                // probably be refused by any IQueryProvider ?? Solution => add a configuration
+                // setting to allow this behaviour ?
+
+                // TODO Discover all specific implementations of the method sorted by specificity and
+                // expand the call into a : iif(o is XXX, o.SubType.Method, iif(..)) expression
+                if (node.Method.IsVirtual && instanceParameter != null && node.Object.Type != node.Method.DeclaringType)
                 {
-                    var info = member.Member as PropertyInfo;
-                    if (info != null)
+                    Tuple<Expression, string> implementation = new Tuple<Expression, string>(instanceParameter, node.Method.Name);
+                    Type currentType;
+                    if (!_methodInheritanceContext.TryGetValue(implementation, out currentType))
                     {
-                        return Decompile(info.GetGetMethod(), member.Expression, new List<Expression>());
+                        currentType = node.Object.Type;
+                        _methodInheritanceContext[implementation] = currentType;
+                    }
+                    else
+                    {
+                        currentType = currentType.BaseType;
+                    }
+                    MethodInfo method = currentType != null ? currentType.GetMethod(node.Method.Name, node.Arguments.Select(a => a.Type).ToArray()) : null;
+                    if (method != null && method != node.Method)
+                    {
+                        shouldDecompileOverriddenCall = true;
+                        currentType = method.DeclaringType;
+                        if (method.IsGenericMethod)
+                        {
+                            method = method.MakeGenericMethod(node.Method.GetGenericArguments());
+                        }
+                        node = Expression.Call(node.Object, method, node.Arguments);
                     }
                 }
-                var methodCall = argument as MethodCallExpression;
-                if (methodCall != null)
+                // END OF WORKAROUND
+                if (node.Method.IsGenericMethod && node.Method.GetGenericMethodDefinition() == typeof(ComputedExtension).GetMethod("Computed", BindingFlags.Static | BindingFlags.Public))
                 {
-                    return Decompile(methodCall.Method, methodCall.Object, methodCall.Arguments);
+                    var argument = node.Arguments.SingleOrDefault();
+
+                    var member = argument as MemberExpression;
+                    if (member != null)
+                    {
+                        var info = member.Member as PropertyInfo;
+                        if (info != null)
+                        {
+                            return Decompile(info.GetGetMethod(), member.Expression, new List<Expression>());
+                        }
+                    }
+                    var methodCall = argument as MethodCallExpression;
+                    if (methodCall != null)
+                    {
+                        return Decompile(methodCall.Method, instanceParameter, methodCall.Arguments);
+                    }
                 }
-            }
 
-            if (ShouldDecompile(node.Method))
+                if (shouldDecompileOverriddenCall || ShouldDecompile(node.Method))
+                {
+                    return Decompile(node.Method, node.Object, node.Arguments);
+                }
+
+                return base.VisitMethodCall(node);
+            }
+            finally
             {
-                return Decompile(node.Method, node.Object, node.Arguments);
+                foreach (var parameterKey in _methodInheritanceContext.Keys.Where(key => key.Item1 == instanceParameter).ToList())
+                    _methodInheritanceContext.Remove(parameterKey);
             }
-
-            return base.VisitMethodCall(node);
         }
 
         protected virtual bool ShouldDecompile(MemberInfo methodInfo)
@@ -63,7 +114,7 @@ namespace DelegateDecompiler
             return Configuration.Instance.ShouldDecompile(methodInfo);
         }
 
-        Expression Decompile(MethodInfo method, Expression instance, IList<Expression> arguments)
+        private Expression Decompile(MethodInfo method, Expression instance, IList<Expression> arguments)
         {
             var expression = method.Decompile();
 
@@ -81,8 +132,8 @@ namespace DelegateDecompiler
                     expressions.Add(parameter, arguments[argIndex++]);
                 }
             }
-
-            return Visit(new ReplaceExpressionVisitor(expressions).Visit(expression.Body));
+            Expression result = new ReplaceExpressionVisitor(expressions).Visit(expression.Body);
+            return Visit(result);
         }
     }
 }

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -170,7 +170,7 @@ namespace DelegateDecompiler
             var implementationsList = new List<KeyValuePair<Type, MethodInfo>>();
             implementationsList.Add(new KeyValuePair<Type, MethodInfo>(method.DeclaringType, method));
             var subclasses = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes().Where(t => t.IsSubclassOf(method.DeclaringType))).ToList();
-            subclasses.Sort((t1, t2) => t1 == null || t2 == null ? 0 : t1.IsSubclassOf(t2) ? 1 : -1);
+            subclasses.Sort((t1, t2) => t1.IsSubclassOf(t2) ? 1 : -1);
             subclasses.ForEach(c =>
             {
                 MethodInfo impl = c.GetMethod(method.Name, method.GetParameters()?.Select(a => a.ParameterType).ToArray());

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -169,8 +169,8 @@ namespace DelegateDecompiler
             }
             var implementationsList = new List<KeyValuePair<Type, MethodInfo>>();
             implementationsList.Add(new KeyValuePair<Type, MethodInfo>(method.DeclaringType, method));
-            var subclasses = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes().Where(t => t.IsSubclassOf(method.DeclaringType))).ToList();
-            subclasses.Sort((t1, t2) => t1.IsSubclassOf(t2) ? 1 : -1);
+            var subclasses = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes().Where(t => t.IsSubclassOf(method.DeclaringType))).Where(t => t != null).ToList();
+            subclasses.Sort((t1, t2) => t1 == null || t2 == null ? 0 : t1.IsSubclassOf(t2) ? 1 : -1);
             foreach (var c in subclasses)
             {
                 MethodInfo impl = c.GetMethod(method.Name, method.GetParameters()?.Select(a => a.ParameterType).ToArray());

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -52,7 +52,6 @@ namespace DelegateDecompiler
                     {
                         Expression expandedCall = null;
                         mostSpecificImplementation = (implementations as List<KeyValuePair<Type, MethodInfo>>).Where(vCall => vCall.Key.IsAssignableFrom(node.Object.Type)).Select(kv => kv.Value).LastOrDefault();
-                        if (mostSpecificImplementation == null) return node;
 
                         var overridingImplementations = (implementations as List<KeyValuePair<Type, MethodInfo>>).Where(vCall => vCall.Key.IsSubclassOf(node.Object.Type)).GroupBy(kv => kv.Key);
                         if (overridingImplementations.Any())
@@ -88,6 +87,7 @@ namespace DelegateDecompiler
                     {
                         mostSpecificImplementation = implementations as MethodInfo;
                     }
+                    if (mostSpecificImplementation == null) return node;
                     node = Expression.Call(node.Object, mostSpecificImplementation, node.Arguments);
                 }
                 finally

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -87,8 +87,8 @@ namespace DelegateDecompiler
                     {
                         mostSpecificImplementation = implementations as MethodInfo;
                     }
-                    if (mostSpecificImplementation == null) return node;
-                    node = Expression.Call(node.Object, mostSpecificImplementation, node.Arguments);
+                    if (mostSpecificImplementation != null)
+                        node = Expression.Call(node.Object, mostSpecificImplementation, node.Arguments);
                 }
                 finally
                 {

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -29,52 +30,72 @@ namespace DelegateDecompiler
 
         private Dictionary<Tuple<Expression, string>, Type> _methodInheritanceContext = new Dictionary<Tuple<Expression, string>, Type>();
 
+        private List<Tuple<Expression, MethodInfo>> _virtualCallContexts = new List<Tuple<Expression, MethodInfo>>();
+
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
             // PROBLEM - the MethodCallExpression does not always (?never?) point to the most
             // specific method for the object when a Computed method is overriden
 
-            Expression instanceParameter = node.Object;
-            //Allows to decompile overriding implementations of a Computed method
-            bool shouldDecompileOverriddenCall = false;
-            try
+            Expression instance = node.Object;
+            // Si _virtualCallContexts contient des items avec le paramètre comme clé
+            // => on a déjà développé l'appel, on se contente de le decompiler
+            // => à la fin, Sinon on génère une expression iif(...) et on pipe les contextes d'appel
+            // on visite l'expression
+
+            // Check whether the call is symbolic or effective
+            bool isExplicitCall = !node.Method.IsVirtual || _virtualCallContexts.Any(vcc => vcc.Item1 == instance);
+            bool shouldDecompile = ShouldDecompile(node.Method) && isExplicitCall;
+            if (!isExplicitCall)
             {
-                // WORKAROUND - find the most specific implementation not used for the parameter and
-                // redirects the call the base implementation when the method is called again in the
-                // same decompilation unit
-
-                // Side Effect => this makes it impossible to use recursive calls but those would
-                // probably be refused by any IQueryProvider ?? Solution => add a configuration
-                // setting to allow this behaviour ?
-
-                // TODO Discover all specific implementations of the method sorted by specificity and
-                // expand the call into a : iif(o is XXX, o.SubType.Method, iif(..)) expression
-                if (node.Method.IsVirtual && instanceParameter != null && node.Object.Type != node.Method.DeclaringType)
+                var castObjects = new HashSet<Expression>();
+                try
                 {
-                    Tuple<Expression, string> implementation = new Tuple<Expression, string>(instanceParameter, node.Method.Name);
-                    Type currentType;
-                    if (!_methodInheritanceContext.TryGetValue(implementation, out currentType))
+                    var implementations = GetImplementationsFor(node.Method);
+                    _virtualCallContexts.Add(new Tuple<Expression, MethodInfo>(instance, node.Method));
+                    if (implementations is IEnumerable)
                     {
-                        currentType = node.Object.Type;
-                        _methodInheritanceContext[implementation] = currentType;
+                        Expression expandedCall = null;
+                        var applicableCalls = (implementations as List<KeyValuePair<Type, MethodInfo>>).Where(vCall => vCall.Key == node.Object.Type || vCall.Key.IsSubclassOf(node.Object.Type));
+                        bool handleObjecasSubType = false;
+                        foreach (var explicitCalls in applicableCalls.GroupBy(kv => kv.Key))
+                        {
+                            var explicitCast = node.Object;
+                            if (handleObjecasSubType) explicitCast = Expression.TypeAs(instance, explicitCalls.Key);
+                            castObjects.Add(explicitCast);
+                            // Register every possible call to base.xxxx from this type hierarchy as
+                            // an explicit call;
+                            _virtualCallContexts.AddRange(explicitCalls.Select(vc => new Tuple<Expression, MethodInfo>(explicitCast, vc.Value)));
+                            // then expand all cases to the the call expression
+                            if (!handleObjecasSubType)
+                            {
+                                expandedCall = base.Visit(Expression.Call(explicitCast, explicitCalls.Select(mostSpecific => mostSpecific.Value).First() as MethodInfo, node.Arguments));
+                                handleObjecasSubType = true;
+                            }
+                            else
+                            {
+                                //TODO check whether to use TypeIs or TypeEquals
+                                expandedCall = Expression.Condition(Expression.TypeIs(node.Object, explicitCalls.Key), base.Visit(Expression.Call(explicitCast, explicitCalls.Select(mostSpecific => mostSpecific.Value).First() as MethodInfo, node.Arguments)), expandedCall);
+                            }
+                        }
+                        return expandedCall;
                     }
                     else
                     {
-                        currentType = currentType.BaseType;
-                    }
-                    MethodInfo method = currentType != null ? currentType.GetMethod(node.Method.Name, node.Arguments.Select(a => a.Type).ToArray()) : null;
-                    if (method != null && method != node.Method)
-                    {
-                        shouldDecompileOverriddenCall = true;
-                        currentType = method.DeclaringType;
-                        if (method.IsGenericMethod)
-                        {
-                            method = method.MakeGenericMethod(node.Method.GetGenericArguments());
-                        }
-                        node = Expression.Call(node.Object, method, node.Arguments);
+                        var implementation = implementations as MethodInfo;
+                        _virtualCallContexts.Add(new Tuple<Expression, MethodInfo>(node.Object, implementation));
+                        node = Expression.Call(node.Object, implementation, node.Arguments);
                     }
                 }
-                // END OF WORKAROUND
+                finally
+                {
+                    // clear all references to node.Object casts
+                    _virtualCallContexts.RemoveAll(items => castObjects.Contains(items.Item1));
+                }
+            }
+
+            try
+            {
                 if (node.Method.IsGenericMethod && node.Method.GetGenericMethodDefinition() == typeof(ComputedExtension).GetMethod("Computed", BindingFlags.Static | BindingFlags.Public))
                 {
                     var argument = node.Arguments.SingleOrDefault();
@@ -91,11 +112,11 @@ namespace DelegateDecompiler
                     var methodCall = argument as MethodCallExpression;
                     if (methodCall != null)
                     {
-                        return Decompile(methodCall.Method, instanceParameter, methodCall.Arguments);
+                        return Decompile(methodCall.Method, instance, methodCall.Arguments);
                     }
                 }
 
-                if (shouldDecompileOverriddenCall || ShouldDecompile(node.Method))
+                if (shouldDecompile)
                 {
                     return Decompile(node.Method, node.Object, node.Arguments);
                 }
@@ -104,8 +125,7 @@ namespace DelegateDecompiler
             }
             finally
             {
-                foreach (var parameterKey in _methodInheritanceContext.Keys.Where(key => key.Item1 == instanceParameter).ToList())
-                    _methodInheritanceContext.Remove(parameterKey);
+                _virtualCallContexts.Remove(new Tuple<Expression, MethodInfo>(node.Object, node.Method));
             }
         }
 
@@ -134,6 +154,37 @@ namespace DelegateDecompiler
             }
             Expression result = new ReplaceExpressionVisitor(expressions).Visit(expression.Body);
             return Visit(result);
+        }
+
+        // values are either MethodInfo or List<MethodInfo>
+        private static Dictionary<MethodInfo, object> _specificImplementations = new Dictionary<MethodInfo, object>();
+
+        private object GetImplementationsFor(MethodInfo method)
+        {
+            object implementations;
+            // first perform a lookup
+            if (_specificImplementations.TryGetValue(method, out implementations))
+            {
+                return implementations;
+            }
+            var implementationsList = new List<KeyValuePair<Type, MethodInfo>>();
+            implementationsList.Add(new KeyValuePair<Type, MethodInfo>(method.DeclaringType, method));
+            var subclasses = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes().Where(t => t.IsSubclassOf(method.DeclaringType))).ToList();
+            subclasses.Sort((t1, t2) => t1.IsSubclassOf(t2) ? 1 : -1);
+            subclasses.ForEach(c =>
+            {
+                MethodInfo impl = c.GetMethod(method.Name, method.GetParameters().Select(a => a.ParameterType).ToArray());
+                if (impl.DeclaringType == c)
+                {
+                    if (impl.IsGenericMethod)
+                    {
+                        impl = method.MakeGenericMethod(impl.GetGenericArguments());
+                    }
+                    implementationsList.Add(new KeyValuePair<Type, MethodInfo>(c, impl));
+                }
+            });
+            _specificImplementations[method] = implementationsList;
+            return implementationsList;
         }
     }
 }

--- a/src/DelegateDecompiler/DefaultConfiguration.cs
+++ b/src/DelegateDecompiler/DefaultConfiguration.cs
@@ -5,13 +5,14 @@ namespace DelegateDecompiler
 {
     public class DefaultConfiguration : Configuration
     {
-        readonly HashSet<MemberInfo> computedMembers = new HashSet<MemberInfo>();
+        private readonly HashSet<MemberInfo> computedMembers = new HashSet<MemberInfo>();
 
         public override bool ShouldDecompile(MemberInfo memberInfo)
         {
-            return memberInfo.GetCustomAttributes(typeof(DecompileAttribute), true).Length > 0 ||
-                   memberInfo.GetCustomAttributes(typeof(ComputedAttribute), true).Length > 0 ||
-                   computedMembers.Contains(memberInfo);
+            // favor lookup to reflection
+            return computedMembers.Contains(memberInfo) ||
+                    memberInfo.GetCustomAttributes(typeof(DecompileAttribute), true).Length > 0 ||
+                    memberInfo.GetCustomAttributes(typeof(ComputedAttribute), true).Length > 0;
         }
 
         public override void RegisterDecompileableMember(MemberInfo property)

--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -260,7 +260,10 @@ namespace DelegateDecompiler
                         var value = state.Stack.Pop();
                         var instance = state.Stack.Pop();
                         var field = (FieldInfo)state.Instruction.Operand;
-                        instance.Expression = BuildMemberInit(instance.Expression, Expression.Bind(field, value));
+                        // FIX - If instance is not an initialisation, we bypass the call and keep
+                        // the instance as the current element
+                        if (instance.Expression.NodeType == ExpressionType.MemberInit || instance.Expression.NodeType == ExpressionType.New)
+                            instance.Expression = BuildMemberInit(instance.Expression, Expression.Bind(field, value));
                     }
                     else if (state.Instruction.OpCode == OpCodes.Ldloc_0)
                     {

--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -260,8 +260,8 @@ namespace DelegateDecompiler
                         var value = state.Stack.Pop();
                         var instance = state.Stack.Pop();
                         var field = (FieldInfo)state.Instruction.Operand;
-                        // FIX - If instance is not an initialisation, we bypass the call and keep
-                        // the instance as the current element
+                        // FIX - If instance is not an initialisation, we bypass the instruction and
+                        // keep the current instance as is
                         if (instance.Expression.NodeType == ExpressionType.MemberInit || instance.Expression.NodeType == ExpressionType.New)
                             instance.Expression = BuildMemberInit(instance.Expression, Expression.Bind(field, value));
                     }

--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -689,8 +689,8 @@ namespace DelegateDecompiler
                         var constructor = state.Instruction.Operand as ConstructorInfo;
                         if (method != null)
                         {
-                            //Handling special System.Linq.Expression.xxxEquals calls
-                            if (method.Name.EndsWith("Equal") && method.DeclaringType == typeof(Expression))
+                            //Handling special System.Linq.Expression.xxxEquals(,,,) calls
+                            if (method.Name.EndsWith("Equal") && method.DeclaringType == typeof(Expression) && method.GetParameters().Count() == 4)
                             {
                                 var eqChkMethod = (MethodInfo)((ConstantExpression)DiscardConversion(state.Stack.Pop())).Value;
                                 bool liftToNull = (bool)((ConstantExpression)AdjustType(state.Stack.Pop(), typeof(bool))).Value;
@@ -705,13 +705,6 @@ namespace DelegateDecompiler
                                     state.Stack.Push(Expression.NotEqual(leftExpr, rightExpr, liftToNull, eqChkMethod));
                                 }
                             }
-                            //////Handling special System.Linq.Expression.Lambda calls
-                            ////else if (method.Name == "Lambda" && method.DeclaringType == typeof(Expression))
-                            ////{
-                            ////    var parameters = state.Stack.Pop();
-                            ////    var body = state.Stack.Pop();
-                            ////    //state.Stack.Push(Expression.Lambda());
-                            ////}
                             else
                             {
                                 Call(state, method);


### PR DESCRIPTION
This proposal addresses a solution solution to my comment on issue #113

The changes also includes other features: 
- the decompilation of Expression.xxx calls into their lambda counterpart (useful with EF)
- the translation of Condition(Func<obj,bool>, Func<obj,bool>, Func<obj,bool>) into AndAlso/OrElse expressions

Besides this, I had to upgrade some packages and target networks to be able to check all tests.
Tell me if that is a problem.