### PR TITLE
Add support for multiple value assignment using BlockExpression return

### DIFF
--- a/src/DelegateDecompiler.Tests/AssignmentTests.cs
+++ b/src/DelegateDecompiler.Tests/AssignmentTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq.Expressions;
 using NUnit.Framework;
 
 namespace DelegateDecompiler.Tests
@@ -11,6 +12,7 @@ namespace DelegateDecompiler.Tests
             private static int staticField;
             private int myField;
             private int MyProperty { get; set; }
+            private int MyAdditionalProperty { get; set; }
 
             public void SetStaticField(int value)
             {
@@ -25,6 +27,12 @@ namespace DelegateDecompiler.Tests
             public void SetMyProperty(int value)
             {
                 MyProperty = value;
+            }
+
+            public void SetMyPropertyAndMyAdditionalProperty(int value, int additionalValue)
+            {
+                MyProperty = value;
+                MyAdditionalProperty = additionalValue;
             }
         }
         
@@ -53,6 +61,18 @@ namespace DelegateDecompiler.Tests
             var expression = method.Decompile();
 
             Assert.That(expression.ToString(), Is.EqualTo("(this, value) => (this.MyProperty = value)"));
+        }
+
+        [Test]
+        public void TestSetPropertyAndAdditionalProperty()
+        {
+            var method = typeof(TestClass).GetMethod(nameof(TestClass.SetMyPropertyAndMyAdditionalProperty));
+            var expression = method.Decompile();
+
+            var block = expression.Body as BlockExpression;
+            Assert.NotNull(block);
+            Assert.That(block.Expressions[0].ToString(), Is.EqualTo("(this.MyProperty = value)"));
+            Assert.That(block.Expressions[1].ToString(), Is.EqualTo("(this.MyAdditionalProperty = additionalValue)"));
         }
     }
 }

--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -78,9 +78,13 @@ namespace DelegateDecompiler
 
             public Expression Final()
             {
-                return Stack.Count == 0
-                       ? Expression.Empty()
-                       : Stack.Pop();
+                switch (Stack.Count)
+                {
+                    case 0: return Expression.Empty();
+                    case 1: return Stack.Pop();
+                    default:
+                        return Expression.Block(Stack.Reverse().Select(address => address.Expression));
+                }
             }
         }
   


### PR DESCRIPTION
These changes implement a solution for #122. After changing the implementation of `Final` I noticed some of the array tests breaking, which I traced back to `InitializeArray` calls being handled incorrectly by DelegateDecompiler. All tests are still passing, so I hope I didn't break anything by adding the `BlockExpression` return.