### PR TITLE
Issue 131

### DIFF
--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -813,18 +813,18 @@ namespace DelegateDecompiler
             var rightType = right.Type;
             var leftType = left.Type;
 
-            left = AdjustBooleanConstant(left, rightType);
-            right = AdjustBooleanConstant(right, leftType);
-            left = ConvertEnumExpressionToUnderlyingType(left);
-            right = ConvertEnumExpressionToUnderlyingType(right);
+			left = AdjustBooleanConstant(left, rightType);
+			right = AdjustBooleanConstant(right, leftType);
+			left = ConvertEnumExpressionToUnderlyingType(left);
+			right = ConvertEnumExpressionToUnderlyingType(right);
 
-	        var leftIsNullable = leftType.IsGenericType && leftType.GetGenericTypeDefinition() == typeof(Nullable<>);
+			var leftIsNullable = leftType.IsGenericType && leftType.GetGenericTypeDefinition() == typeof(Nullable<>);
 	        var rightIsNullable = rightType.IsGenericType && rightType.GetGenericTypeDefinition() == typeof(Nullable<>);
 
 			if (leftIsNullable && !rightIsNullable)
 	        {
 		        var propertyHasValue = Expression.Property(left.Expression, nameof(Nullable<int>.HasValue));
-		        var propertyValue = Expression.Property(left.Expression, nameof(Nullable<int>.Value));
+		        var propertyValue = ConvertEnumExpressionToUnderlyingType(Expression.Property(left.Expression, nameof(Nullable<int>.Value)));
 		        var binary = Expression.MakeBinary(expressionType, propertyValue, right);
 				return Expression.Condition(Expression.Equal(propertyHasValue, Expression.Constant(true)),
 					Expression.Convert(binary, binary.Type), Expression.New(binary.Type));
@@ -832,7 +832,7 @@ namespace DelegateDecompiler
 			if (!leftIsNullable && rightIsNullable)
 	        {
 		        var propertyHasValue = Expression.Property(right.Expression, nameof(Nullable<int>.HasValue));
-		        var propertyValue = Expression.Property(right.Expression, nameof(Nullable<int>.Value));
+		        var propertyValue = ConvertEnumExpressionToUnderlyingType(Expression.Property(right.Expression, nameof(Nullable<int>.Value)));
 		        var binary = Expression.MakeBinary(expressionType, propertyValue, left);
 				return Expression.Condition(Expression.Equal(propertyHasValue, Expression.Constant(true)),
 					Expression.Convert(binary, binary.Type), Expression.New(binary.Type));

--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -825,15 +825,17 @@ namespace DelegateDecompiler
 	        {
 		        var propertyHasValue = Expression.Property(left.Expression, nameof(Nullable<int>.HasValue));
 		        var propertyValue = Expression.Property(left.Expression, nameof(Nullable<int>.Value));
+		        var binary = Expression.MakeBinary(expressionType, propertyValue, right);
 				return Expression.Condition(Expression.Equal(propertyHasValue, Expression.Constant(true)),
-					Expression.Convert(Expression.MakeBinary(expressionType, propertyValue, right), leftType), Expression.Default(leftType));
+					Expression.Convert(binary, binary.Type), Expression.New(binary.Type));
 			}
 			if (!leftIsNullable && rightIsNullable)
 	        {
 		        var propertyHasValue = Expression.Property(right.Expression, nameof(Nullable<int>.HasValue));
 		        var propertyValue = Expression.Property(right.Expression, nameof(Nullable<int>.Value));
-		        return Expression.Condition(Expression.Equal(propertyHasValue, Expression.Constant(true)),
-			        Expression.Convert(Expression.MakeBinary(expressionType, propertyValue, left), rightType), Expression.Default(rightType));
+		        var binary = Expression.MakeBinary(expressionType, propertyValue, left);
+				return Expression.Condition(Expression.Equal(propertyHasValue, Expression.Constant(true)),
+					Expression.Convert(binary, binary.Type), Expression.New(binary.Type));
 			}
 
 			return Expression.MakeBinary(expressionType, left, right);


### PR DESCRIPTION
Ok so here is an up to date pull request which should resolve the issue with the latest version of Visual Studio and nullable types.

Basically I am dropping any calls to ValueOrDefault.
Where I find an expression which needs to access a nullable type I am substituting in an appropriate expression which accesses the Value or returns the default value. This way I am removing all calls to ValueOrDefault which is not supported in Linq to Entities.

I have run the changes through the entire test harness and all tests passed successfully