### PR TITLE
Adding support for custom expression maps per configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ Again, the `FullName` property will be decompiled:
 bool exists = db.Employees.Any(employee => (employee.FirstName + " " + employee.LastName) == "Test User");
 ```
 
+### Expression maps per configuration
+If you require custom mapping of computed expressions per configuration, you can use the `Configuration.AddExpressionMap<TEntity, TProperty>()` method.
+
+```csharp
+Configuration.Instance.AddExpressionMap<Employee, string>(x => x.FullName, x => x.FirstName + " " + x.LastName);
+
+var employees = (from employee in db.Employees
+                 where employee.FullName == "Test User"
+                 select employee).ToList();
+```
+
 ## Using with EntityFramework and other ORMs
 
 If you are using ORM specific features, like EF's `Include`, `AsNoTracking` or NH's `Fetch` then `Decompile` method should be called after all ORM specific methods, otherwise it may not work. Ideally use `Decompile` extension method just before materialization methods such as `ToList`, `ToArray`, `First`, `FirstOrDefault`, `Count`, `Any`, and etc.

--- a/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Concretes/EfPerson.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Concretes/EfPerson.cs
@@ -38,6 +38,13 @@ namespace DelegateDecompiler.EntityFramework.Tests.EfItems.Concretes
         [Computed]
         public string FullNameHandleNull { get { return FirstName + (MiddleName == null ? "" : " ") + MiddleName + " " + LastName; } }
 
+        public string FullNameExpressionMap { get; set; }
+
+        public string GetFullNameExpressionMap()
+        {
+            return null;
+        }
+
         [Computed]
         public string UseOrderToFormatNameStyle { get
         {

--- a/src/DelegateDecompiler.EntityFramework.Tests/EfItems/EfTestDbContext.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/EfItems/EfTestDbContext.cs
@@ -46,6 +46,10 @@ namespace DelegateDecompiler.EntityFramework.Tests.EfItems
             modelBuilder.Entity<EfPerson>()
                 .Computed(x => x.FullNameNoAttibute)
                 .Computed(x => x.GetFullNameNoAttibute());
+
+            modelBuilder.Entity<EfPerson>()
+                .Computed(x => x.FullNameExpressionMap, x => x.FirstName + " " + x.MiddleName + " " + x.LastName)
+                .Computed(x => x.GetFullNameExpressionMap(), x => x.FirstName + " " + x.MiddleName + " " + x.LastName);
             
             modelBuilder.Entity<Dog>();
             modelBuilder.Entity<HoneyBee>();

--- a/src/DelegateDecompiler.EntityFramework.Tests/EntityTypeConfigurationExtensionsTests.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/EntityTypeConfigurationExtensionsTests.cs
@@ -19,6 +19,18 @@ namespace DelegateDecompiler.EntityFramework.Tests
         }
 
         [Test]
+        public void ComputedExpressionMapShouldRegisterPropertyAsDecompileable()
+        {
+            Assert.Null(InstanceGetter());
+            var configuration = new DefaultConfiguration();
+            Configuration.Configure(configuration);
+
+            default(EntityTypeConfiguration<TestClass>).Computed(x => x.Property, x => x.Field);
+
+            Assert.IsTrue(configuration.ShouldDecompile(typeof(TestClass).GetProperty(nameof(TestClass.Property))));
+        }
+
+        [Test]
         public void ComputedShouldRegisterMethodAsDecompileable()
         {
             Assert.Null(InstanceGetter());

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test01Select.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test01Select.cs
@@ -89,6 +89,23 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
         }
 
         [Test]
+        public void TestSelectPropertyWithExpressionMap()
+        {
+            using (var env = new MethodEnvironment(classEnv))
+            {
+                //SETUP
+                var linq = env.Db.EfPersons.Select(x => x.FirstName + " " + x.MiddleName + " " + x.LastName).ToList();
+
+                //ATTEMPT
+                env.AboutToUseDelegateDecompiler();
+                var dd = env.Db.EfPersons.Select(x => x.FullNameExpressionMap).Decompile().ToList();
+
+                //VERIFY
+                env.CompareAndLogList(linq, dd);
+            }
+        }
+
+        [Test]
         public void TestSelectMethodWithoutComputedAttribute()
         {
             using (var env = new MethodEnvironment(classEnv))
@@ -99,6 +116,23 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
                 //ATTEMPT
                 env.AboutToUseDelegateDecompiler();
                 var dd = env.Db.EfPersons.Select(x => x.GetFullNameNoAttibute()).Decompile().ToList();
+
+                //VERIFY
+                env.CompareAndLogList(linq, dd);
+            }
+        }
+
+        [Test]
+        public void TestSelectMethodWithExpressionMap()
+        {
+            using (var env = new MethodEnvironment(classEnv))
+            {
+                //SETUP
+                var linq = env.Db.EfPersons.Select(x => x.FirstName + " " + x.MiddleName + " " + x.LastName).ToList();
+
+                //ATTEMPT
+                env.AboutToUseDelegateDecompiler();
+                var dd = env.Db.EfPersons.Select(x => x.GetFullNameExpressionMap()).Decompile().ToList();
 
                 //VERIFY
                 env.CompareAndLogList(linq, dd);

--- a/src/DelegateDecompiler.EntityFramework/EntityTypeConfigurationExtensions.cs
+++ b/src/DelegateDecompiler.EntityFramework/EntityTypeConfigurationExtensions.cs
@@ -16,6 +16,13 @@ namespace DelegateDecompiler.EntityFramework
             return configuration;
         }
 
+        public static EntityTypeConfiguration<T> Computed<T, TResult>(this EntityTypeConfiguration<T> configuration, Expression<Func<T, TResult>> expression, Expression<Func<T, TResult>> expressionMap) where T : class
+        {
+            Configuration.Instance.AddExpressionMap(expression, expressionMap);
+
+            return configuration;
+        }
+
         static MemberInfo ExtractMemberInfo(Expression body)
         {
             if (body.NodeType == ExpressionType.MemberAccess)

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.24.0 on Sunday, 29 April 2018 02:03
+## Documentation produced for DelegateDecompiler, version 0.24.0 on Saturday, 22 September 2018 09:41
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -29,7 +29,13 @@ More will appear as we move forward.*
   * Bool Equals Static Variable (line 53)
   * Int Equals Constant (line 70)
   * Select Property Without Computed Attribute (line 87)
-  * Select Method Without Computed Attribute (line 104)
+  * Select Property With Expression Map (line 104)
+  * Select Method Without Computed Attribute (line 121)
+  * Select Method With Expression Map (line 138)
+  * Select Abstract Member Over Tph Hierarchy (line 155)
+  * Select Abstract Member Over Tph Hierarchy After Restricting To Subtype (line 172)
+- **Not Supported**
+  * Select Multiple Levels Of Abstract Members Over Tph Hierarchy (line 189)
 
 #### [Select Async](../TestGroup05BasicFeatures/Test02SelectAsync.cs):
 - Supported
@@ -57,6 +63,9 @@ More will appear as we move forward.*
   * Where Bool Equals Constant (line 33)
   * Where Bool Equals Static Variable (line 52)
   * Where Int Equals Constant (line 69)
+  * Where Filters On Abstract Members Over Tph Hierarchy (line 86)
+- **Not Supported**
+  * Where Filters On Multiple Levels Of Abstract Members Over Tph Hierarchy (line 103)
 
 #### [Single](../TestGroup05BasicFeatures/Test10Single.cs):
 - Supported
@@ -69,16 +78,28 @@ More will appear as we move forward.*
 
 ### Group: Order Take
 #### [Order By](../TestGroup10OrderTake/Test01OrderBy.cs):
+- Supported
+  * Order By Children Count (line 33)
+  * Order By Children Count Then By String Length (line 51)
+  * Where Any Children Then Order By Children Count (line 69)
 
 #### [Skip Take](../TestGroup10OrderTake/Test02SkipTake.cs):
+- Supported
+  * Order By Children Count Then Take (line 33)
+  * Order By Children Count Then Skip And Take (line 51)
+  * Where Any Children Then Order By Then Skip Take (line 69)
 
 
 ### Group: Quantifier Operators
 #### [Any](../TestGroup12QuantifierOperators/Test01Any.cs):
+- Supported
+  * Any Children (line 32)
+  * Any Children With Filter (line 49)
 
 #### [All](../TestGroup12QuantifierOperators/Test02All.cs):
 - Supported
   * Singleton All Filter (line 32)
+  * All Filter On Children Int (line 49)
 
 #### [Contains](../TestGroup12QuantifierOperators/Test03Contains.cs):
 - Supported
@@ -87,8 +108,18 @@ More will appear as we move forward.*
 
 ### Group: Aggregation
 #### [Count](../TestGroup15Aggregation/Test01Count.cs):
+- Supported
+  * Count Children (line 33)
+  * Count Children With Filter (line 51)
+  * Count Children With Filter By Closure (line 69)
+  * Count Children With Filter By External Closure (line 88)
+  * Count Children With Filter By External Closure2 (line 108)
+  * Singleton Count Children With Filter (line 126)
 
 #### [Sum](../TestGroup15Aggregation/Test02Sum.cs):
+- Supported
+  * Singleton Sum Children (line 33)
+  * Sum Count In Children Where Children Can Be None (line 51)
 
 
 ### Group: Types

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.24.0 on Sunday, 29 April 2018 02:03
+## Documentation produced for DelegateDecompiler, version 0.24.0 on Saturday, 22 September 2018 09:41
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -53,13 +53,43 @@ More will appear as we move forward.*
 
 ```
 
-  * Select Method Without Computed Attribute (line 104)
+  * Select Property With Expression Map (line 104)
      * T-Sql executed is
 
 ```SQL
 
 ```
 
+  * Select Method Without Computed Attribute (line 121)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * Select Method With Expression Map (line 138)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * Select Abstract Member Over Tph Hierarchy (line 155)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * Select Abstract Member Over Tph Hierarchy After Restricting To Subtype (line 172)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+- **Not Supported**
+  * Select Multiple Levels Of Abstract Members Over Tph Hierarchy (line 189)
 
 #### [Select Async](../TestGroup05BasicFeatures/Test02SelectAsync.cs):
 - Supported
@@ -177,6 +207,15 @@ More will appear as we move forward.*
 
 ```
 
+  * Where Filters On Abstract Members Over Tph Hierarchy (line 86)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+- **Not Supported**
+  * Where Filters On Multiple Levels Of Abstract Members Over Tph Hierarchy (line 103)
 
 #### [Single](../TestGroup05BasicFeatures/Test10Single.cs):
 - Supported
@@ -201,16 +240,82 @@ More will appear as we move forward.*
 
 ### Group: Order Take
 #### [Order By](../TestGroup10OrderTake/Test01OrderBy.cs):
+- Supported
+  * Order By Children Count (line 33)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * Order By Children Count Then By String Length (line 51)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * Where Any Children Then Order By Children Count (line 69)
+     * T-Sql executed is
+
+```SQL
+
+```
+
 
 #### [Skip Take](../TestGroup10OrderTake/Test02SkipTake.cs):
+- Supported
+  * Order By Children Count Then Take (line 33)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * Order By Children Count Then Skip And Take (line 51)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * Where Any Children Then Order By Then Skip Take (line 69)
+     * T-Sql executed is
+
+```SQL
+
+```
+
 
 
 ### Group: Quantifier Operators
 #### [Any](../TestGroup12QuantifierOperators/Test01Any.cs):
+- Supported
+  * Any Children (line 32)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * Any Children With Filter (line 49)
+     * T-Sql executed is
+
+```SQL
+
+```
+
 
 #### [All](../TestGroup12QuantifierOperators/Test02All.cs):
 - Supported
   * Singleton All Filter (line 32)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * All Filter On Children Int (line 49)
      * T-Sql executed is
 
 ```SQL
@@ -231,8 +336,66 @@ More will appear as we move forward.*
 
 ### Group: Aggregation
 #### [Count](../TestGroup15Aggregation/Test01Count.cs):
+- Supported
+  * Count Children (line 33)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * Count Children With Filter (line 51)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * Count Children With Filter By Closure (line 69)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * Count Children With Filter By External Closure (line 88)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * Count Children With Filter By External Closure2 (line 108)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * Singleton Count Children With Filter (line 126)
+     * T-Sql executed is
+
+```SQL
+
+```
+
 
 #### [Sum](../TestGroup15Aggregation/Test02Sum.cs):
+- Supported
+  * Singleton Sum Children (line 33)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+  * Sum Count In Children Where Children Can Be None (line 51)
+     * T-Sql executed is
+
+```SQL
+
+```
+
 
 
 ### Group: Types

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.24.0 on Sunday, 29 April 2018 02:03
+## Documentation produced for DelegateDecompiler, version 0.24.0 on Saturday, 22 September 2018 09:41
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -24,22 +24,30 @@ More will appear as we move forward.*
 
 ### Group: Basic Features
 - Supported
-  * [Select](../TestGroup05BasicFeatures/Test01Select.cs) (5 tests)
   * [Select Async](../TestGroup05BasicFeatures/Test02SelectAsync.cs) (3 tests)
   * [Equals And Not Equals](../TestGroup05BasicFeatures/Test03EqualsAndNotEquals.cs) (4 tests)
   * [Nullable](../TestGroup05BasicFeatures/Test04Nullable.cs) (5 tests)
-  * [Where](../TestGroup05BasicFeatures/Test05Where.cs) (3 tests)
   * [Single](../TestGroup05BasicFeatures/Test10Single.cs) (1 tests)
   * [Single Async](../TestGroup05BasicFeatures/Test11SingleAsync.cs) (1 tests)
+- **Partially Supported**
+  * [Select](../TestGroup05BasicFeatures/Test01Select.cs) (9 of 10 tests passed)
+  * [Where](../TestGroup05BasicFeatures/Test05Where.cs) (4 of 5 tests passed)
 
 ### Group: Order Take
+- Supported
+  * [Order By](../TestGroup10OrderTake/Test01OrderBy.cs) (3 tests)
+  * [Skip Take](../TestGroup10OrderTake/Test02SkipTake.cs) (3 tests)
 
 ### Group: Quantifier Operators
 - Supported
-  * [All](../TestGroup12QuantifierOperators/Test02All.cs) (1 tests)
+  * [Any](../TestGroup12QuantifierOperators/Test01Any.cs) (2 tests)
+  * [All](../TestGroup12QuantifierOperators/Test02All.cs) (2 tests)
   * [Contains](../TestGroup12QuantifierOperators/Test03Contains.cs) (1 tests)
 
 ### Group: Aggregation
+- Supported
+  * [Count](../TestGroup15Aggregation/Test01Count.cs) (6 tests)
+  * [Sum](../TestGroup15Aggregation/Test02Sum.cs) (2 tests)
 
 ### Group: Types
 - Supported

--- a/src/DelegateDecompiler.EntityFrameworkCore/EntityTypeConfigurationExtensions.cs
+++ b/src/DelegateDecompiler.EntityFrameworkCore/EntityTypeConfigurationExtensions.cs
@@ -16,6 +16,13 @@ namespace DelegateDecompiler.EntityFrameworkCore
             return configuration;
         }
 
+        public static EntityTypeBuilder<T> Computed<T, TResult>(this EntityTypeBuilder<T> configuration, Expression<Func<T, TResult>> expression, Expression<Func<T, TResult>> expressionMap) where T : class
+        {
+            Configuration.Instance.AddExpressionMap(expression, expressionMap);
+
+            return configuration;
+        }
+
         static MemberInfo ExtractMemberInfo(Expression body)
         {
             if (body.NodeType == ExpressionType.MemberAccess)
@@ -31,6 +38,7 @@ namespace DelegateDecompiler.EntityFrameworkCore
             {
                 return ((MethodCallExpression) body).Method;
             }
+
             throw new ArgumentException("Expression expected to be of MemberAccess or Call type, but got " + body.NodeType);
         }
     }

--- a/src/DelegateDecompiler.Tests/Employee.cs
+++ b/src/DelegateDecompiler.Tests/Employee.cs
@@ -24,6 +24,13 @@ namespace DelegateDecompiler.Tests
             get { return FirstName + " " + LastName; }
         }
 
+        public string FullNameWithExpressionMap { get; set; }
+
+        public string GetFullNameWithExpressionMap()
+        {
+            return null;
+        }
+
         public string FullNameWithoutAttribute
         {
             get { return FirstName + " " + LastName; }

--- a/src/DelegateDecompiler.Tests/ExpressionMapTests.cs
+++ b/src/DelegateDecompiler.Tests/ExpressionMapTests.cs
@@ -1,0 +1,71 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace DelegateDecompiler.Tests
+{
+    public class ExpressionMapTests : ConfigurationTestsBase
+    {
+        [Test]
+        public void ExpressionMapShouldRegisterPropertyAsDecompileable()
+        {
+            Assert.Null(InstanceGetter());
+            var configuration = new DefaultConfiguration();
+            configuration.AddExpressionMap<Employee, string>(x => x.FullNameWithExpressionMap, x => x.FirstName + " " + x.LastName);
+            Configuration.Configure(configuration);
+            Assert.IsTrue(configuration.ShouldDecompile(typeof(Employee).GetProperty(nameof(Employee.FullNameWithExpressionMap))));
+        }
+
+        [Test]
+        public void NoExpressionMapShouldNotRegisterPropertyAsDecompileable()
+        {
+            Assert.Null(InstanceGetter());
+            var configuration = new DefaultConfiguration();
+            Configuration.Configure(configuration);
+            Assert.IsFalse(configuration.ShouldDecompile(typeof(Employee).GetProperty(nameof(Employee.FullNameWithExpressionMap))));
+        }
+
+        [Test]
+        public void ExpressionMapShouldDecompile()
+        {
+            Assert.Null(InstanceGetter());
+            var configuration = new DefaultConfiguration();
+            configuration.AddExpressionMap<Employee, string>(x => x.FullNameWithExpressionMap, x => x.FirstName + " " + x.LastName);
+            Configuration.Configure(configuration);
+
+
+            var employees = new[] { new Employee { FirstName = "Test", LastName = "User" } };
+
+            var expected = (from employee in employees.AsQueryable()
+                            where (employee.FirstName + " " + employee.LastName) == "Test User"
+                            select employee);
+
+            var actual = (from employee in employees.AsQueryable()
+                          where employee.FullNameWithExpressionMap == "Test User"
+                          select employee).Decompile();
+
+            Assert.AreEqual(expected.Expression.ToString(), actual.Expression.ToString());
+        }
+
+        [Test]
+        public void ExpressionMapMethodShouldDecompile()
+        {
+            Assert.Null(InstanceGetter());
+            var configuration = new DefaultConfiguration();
+            configuration.AddExpressionMap<Employee, string>(x => x.GetFullNameWithExpressionMap(), x => x.FirstName + " " + x.LastName);
+            Configuration.Configure(configuration);
+
+
+            var employees = new[] { new Employee { FirstName = "Test", LastName = "User" } };
+
+            var expected = (from employee in employees.AsQueryable()
+                            where (employee.FirstName + " " + employee.LastName) == "Test User"
+                            select employee);
+
+            var actual = (from employee in employees.AsQueryable()
+                          where employee.GetFullNameWithExpressionMap() == "Test User"
+                          select employee).Decompile();
+
+            Assert.AreEqual(expected.Expression.ToString(), actual.Expression.ToString());
+        }
+    }
+}

--- a/src/DelegateDecompiler/Configuration.cs
+++ b/src/DelegateDecompiler/Configuration.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime;
 
 namespace DelegateDecompiler
 {
@@ -7,6 +11,8 @@ namespace DelegateDecompiler
     {
         private static readonly object locker = new object();
         private static volatile Configuration instance;
+
+        private ConcurrentDictionary<MemberInfo, LambdaExpression> ExpressionMaps { get; set; } = new ConcurrentDictionary<MemberInfo, LambdaExpression>();
 
         internal static Configuration Instance
         {
@@ -43,11 +49,61 @@ namespace DelegateDecompiler
             throw new InvalidOperationException("DelegateDecompiler has been configured already");
         }
 
+        public void AddExpressionMap<TEntity, TProperty>(Expression<Func<TEntity, TProperty>> expression, Expression<Func<TEntity, TProperty>> expressionMap)
+            where TEntity : class
+        {
+            var memberInfo = ExtractMemberInfo(expression);
+
+            RegisterDecompileableMember(memberInfo);
+
+            if (memberInfo is PropertyInfo)
+            {
+                memberInfo = ((PropertyInfo)memberInfo).GetGetMethod();
+            }
+            
+            ExpressionMaps[memberInfo] = expressionMap;
+        }
+
+        public bool TryGetExpressionMap(MemberInfo memberInfo, out LambdaExpression expression)
+        {
+            if (ExpressionMaps.ContainsKey(memberInfo))
+            {
+                expression = ExpressionMaps[memberInfo];
+
+                return true;
+            }
+
+            expression = null;
+            return false;
+        }
+
         public abstract bool ShouldDecompile(MemberInfo memberInfo);
 
         public virtual void RegisterDecompileableMember(MemberInfo property)
         {
             throw new NotImplementedException("The method RegisterDecompileableMember of Configuration is not implemented. Please implement it in your custom configuration class.");
+        }
+
+        private static MemberInfo ExtractMemberInfo(Expression body)
+        {
+            if (body.NodeType == ExpressionType.MemberAccess)
+            {
+                var member = ((MemberExpression)body).Member;
+                if (!(member is PropertyInfo))
+                {
+                    throw new InvalidOperationException("MemberExpression expected to have a Member of PropertyInfo type, but got " + member.GetType().Name);
+                }
+                return member;
+            }
+            if (body.NodeType == ExpressionType.Call)
+            {
+                return ((MethodCallExpression)body).Method;
+            }
+            if (body.NodeType == ExpressionType.Lambda)
+            {
+                return ExtractMemberInfo(((LambdaExpression)body).Body);
+            }
+            throw new ArgumentException("Expression expected to be of MemberAccess or Call type, but got " + body.NodeType);
         }
     }
 }

--- a/src/DelegateDecompiler/DecompileExtensions.cs
+++ b/src/DelegateDecompiler/DecompileExtensions.cs
@@ -35,7 +35,18 @@ namespace DelegateDecompiler
 
         public static LambdaExpression Decompile(this MethodInfo method, Type declaringType)
         {
-            return Cache.GetOrAdd(Tuple.Create(declaringType, method), DecompileDelegate).Value;
+            LambdaExpression expression;
+
+            if (Configuration.Instance.TryGetExpressionMap(method, out LambdaExpression expressionMap))
+            {
+                expression = Cache.GetOrAdd(Tuple.Create(declaringType, method), new Lazy<LambdaExpression>(() => expressionMap)).Value;
+            }
+            else
+            {
+                expression = Cache.GetOrAdd(Tuple.Create(declaringType, method), DecompileDelegate).Value;
+            }
+
+            return expression;
         }
 
         public static IQueryable<T> Decompile<T>(this IQueryable<T> self)


### PR DESCRIPTION
Before, expression maps were global across all usages of the model. With this change, an expression map can be defined per configuration, overriding the expression defined on the property.