### PR TITLE
Removing Endrun updates 

### DIFF
--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test01Select.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test01Select.cs
@@ -145,11 +145,11 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
             using (var env = new MethodEnvironment(classEnv))
             {
                 //SETUP
-                var linq = env.Db.LivingBeeing.OfType<Animal>().ToList().Select(p => p.Species + " : " + p.IsPet).ToList();
+                var linq = env.Db.LivingBeeing.OfType<Animal>().ToList().Select(p => string.Concat(p.Species, " : ", p.IsPet)).ToList();
 
                 //ATTEMPT
                 env.AboutToUseDelegateDecompiler();
-                var dd = env.Db.LivingBeeing.OfType<Animal>().Select(p => p.Species + " : " + p.IsPet).Decompile().ToList();
+                var dd = env.Db.LivingBeeing.OfType<Animal>().Select(p => string.Concat(p.Species, " : ", p.IsPet)).Decompile().ToList();
 
                 //VERIFY
                 env.CompareAndLogList(linq, dd);

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test05Where.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test05Where.cs
@@ -93,11 +93,11 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
             using (var env = new MethodEnvironment(classEnv))
             {
                 //SETUP
-                var linq = env.Db.LivingBeeing.OfType<Animal>().ToList().Where(p => p.Species + " : " + p.IsPet == "Apis mellifera : False").Select(x => x.Id).ToList();
+                var linq = env.Db.LivingBeeing.OfType<Animal>().ToList().Where(p => string.Concat(p.Species, " : ", p.IsPet) == "Apis mellifera : False").Select(x => x.Id).ToList();
 
                 //ATTEMPT
                 env.AboutToUseDelegateDecompiler();
-                var dd = env.Db.LivingBeeing.OfType<Animal>().Where(p => p.Species + " : " + p.IsPet == "Apis mellifera : False").Select(x => x.Id).Decompile().ToList();
+                var dd = env.Db.LivingBeeing.OfType<Animal>().Where(p => string.Concat(p.Species, " : ", p.IsPet) == "Apis mellifera : False").Select(x => x.Id).Decompile().ToList();
 
                 //VERIFY
                 env.CompareAndLogList(linq, dd);

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup99SaveResults/Test99SaveResults.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup99SaveResults/Test99SaveResults.cs
@@ -9,9 +9,11 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup99SaveResults
         [Test]
         public void EndRun()
         {
+#if !DEBUG
             MasterEnvironment.UpdateDocumentationIfLooksLikeAFullRun();
             //var markupResults = MasterEnvironment.ResultsAsMarkup( OutputVersions.Summary);
             //Console.Write(markupResults);
+#endif
         }
 
     }

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.25.0 on Wednesday, 02 January 2019 21:20
+## Documentation produced for DelegateDecompiler, version 0.25.0 on Friday, 04 January 2019 01:24
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -25,15 +25,14 @@ More will appear as we move forward.*
 ### Group: Basic Features
 #### [Select](../TestGroup05BasicFeatures/Test01Select.cs):
 - Supported
-  * Bool Equals Constant (line 34)
-  * Bool Equals Static Variable (line 53)
-  * Int Equals Constant (line 70)
-  * Select Property Without Computed Attribute (line 87)
-  * Select Method Without Computed Attribute (line 104)
-  * Select Abstract Member Over Tph Hierarchy (line 121)
-  * Select Abstract Member Over Tph Hierarchy After Restricting To Subtype (line 138)
-- **Not Supported**
-  * Select Multiple Levels Of Abstract Members Over Tph Hierarchy (line 155)
+  * Bool Equals Constant (line 33)
+  * Bool Equals Static Variable (line 52)
+  * Int Equals Constant (line 69)
+  * Select Property Without Computed Attribute (line 86)
+  * Select Method Without Computed Attribute (line 103)
+  * Select Abstract Member Over Tph Hierarchy (line 120)
+  * Select Abstract Member Over Tph Hierarchy After Restricting To Subtype (line 137)
+  * Select Multiple Levels Of Abstract Members Over Tph Hierarchy (line 154)
 
 #### [Select Async](../TestGroup05BasicFeatures/Test02SelectAsync.cs):
 - Supported
@@ -62,7 +61,6 @@ More will appear as we move forward.*
   * Where Bool Equals Static Variable (line 52)
   * Where Int Equals Constant (line 69)
   * Where Filters On Abstract Members Over Tph Hierarchy (line 86)
-- **Not Supported**
   * Where Filters On Multiple Levels Of Abstract Members Over Tph Hierarchy (line 103)
 
 #### [Single](../TestGroup05BasicFeatures/Test10Single.cs):

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.25.0 on Wednesday, 02 January 2019 21:20
+## Documentation produced for DelegateDecompiler, version 0.25.0 on Friday, 04 January 2019 01:24
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -25,57 +25,62 @@ More will appear as we move forward.*
 ### Group: Basic Features
 #### [Select](../TestGroup05BasicFeatures/Test01Select.cs):
 - Supported
-  * Bool Equals Constant (line 34)
+  * Bool Equals Constant (line 33)
      * T-Sql executed is
 
 ```SQL
 
 ```
 
-  * Bool Equals Static Variable (line 53)
+  * Bool Equals Static Variable (line 52)
      * T-Sql executed is
 
 ```SQL
 
 ```
 
-  * Int Equals Constant (line 70)
+  * Int Equals Constant (line 69)
      * T-Sql executed is
 
 ```SQL
 
 ```
 
-  * Select Property Without Computed Attribute (line 87)
+  * Select Property Without Computed Attribute (line 86)
      * T-Sql executed is
 
 ```SQL
 
 ```
 
-  * Select Method Without Computed Attribute (line 104)
+  * Select Method Without Computed Attribute (line 103)
      * T-Sql executed is
 
 ```SQL
 
 ```
 
-  * Select Abstract Member Over Tph Hierarchy (line 121)
+  * Select Abstract Member Over Tph Hierarchy (line 120)
      * T-Sql executed is
 
 ```SQL
 
 ```
 
-  * Select Abstract Member Over Tph Hierarchy After Restricting To Subtype (line 138)
+  * Select Abstract Member Over Tph Hierarchy After Restricting To Subtype (line 137)
      * T-Sql executed is
 
 ```SQL
 
 ```
 
-- **Not Supported**
-  * Select Multiple Levels Of Abstract Members Over Tph Hierarchy (line 155)
+  * Select Multiple Levels Of Abstract Members Over Tph Hierarchy (line 154)
+     * T-Sql executed is
+
+```SQL
+
+```
+
 
 #### [Select Async](../TestGroup05BasicFeatures/Test02SelectAsync.cs):
 - Supported
@@ -200,8 +205,13 @@ More will appear as we move forward.*
 
 ```
 
-- **Not Supported**
   * Where Filters On Multiple Levels Of Abstract Members Over Tph Hierarchy (line 103)
+     * T-Sql executed is
+
+```SQL
+
+```
+
 
 #### [Single](../TestGroup05BasicFeatures/Test10Single.cs):
 - Supported

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.25.0 on Wednesday, 02 January 2019 21:20
+## Documentation produced for DelegateDecompiler, version 0.25.0 on Friday, 04 January 2019 01:24
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -24,14 +24,13 @@ More will appear as we move forward.*
 
 ### Group: Basic Features
 - Supported
+  * [Select](../TestGroup05BasicFeatures/Test01Select.cs) (8 tests)
   * [Select Async](../TestGroup05BasicFeatures/Test02SelectAsync.cs) (3 tests)
   * [Equals And Not Equals](../TestGroup05BasicFeatures/Test03EqualsAndNotEquals.cs) (4 tests)
   * [Nullable](../TestGroup05BasicFeatures/Test04Nullable.cs) (5 tests)
+  * [Where](../TestGroup05BasicFeatures/Test05Where.cs) (5 tests)
   * [Single](../TestGroup05BasicFeatures/Test10Single.cs) (1 tests)
   * [Single Async](../TestGroup05BasicFeatures/Test11SingleAsync.cs) (1 tests)
-- **Partially Supported**
-  * [Select](../TestGroup05BasicFeatures/Test01Select.cs) (7 of 8 tests passed)
-  * [Where](../TestGroup05BasicFeatures/Test05Where.cs) (4 of 5 tests passed)
 
 ### Group: Order Take
 - Supported

--- a/src/DelegateDecompiler.Tests/DecompilerTestsBase.cs
+++ b/src/DelegateDecompiler.Tests/DecompilerTestsBase.cs
@@ -18,7 +18,7 @@ namespace DelegateDecompiler.Tests
         protected static void Test<T>(Expression<T> expected, T compiled)
         {
             //Double cast required as we can not convert T to Delegate directly
-            var decompiled = ((Delegate) ((object) compiled)).Decompile();
+            var decompiled = (LambdaExpression)DecompileExpressionVisitor.Decompile(((Delegate) ((object) compiled)).Decompile());
 
             var x = expected.Body.ToString();
             Console.WriteLine(x);
@@ -31,7 +31,8 @@ namespace DelegateDecompiler.Tests
         protected static void Test<T>(Expression<T> expected, MethodInfo compiled)
         {
             //Double cast required as we can not convert T to Delegate directly
-            var decompiled = compiled.Decompile();
+            //var decompiled = compiled.Decompile();
+            var decompiled = (LambdaExpression)DecompileExpressionVisitor.Decompile(compiled.Decompile());
 
             var x = expected.Body.ToString();
             Console.WriteLine(x);
@@ -44,7 +45,8 @@ namespace DelegateDecompiler.Tests
         protected static void Test<T>(Expression<T> expected1, Expression<T> expected2, T compiled)
         {
             //Double cast required as we can not convert T to Delegate directly
-            var decompiled = ((Delegate) ((object) compiled)).Decompile();
+            //var decompiled = ((Delegate) ((object) compiled)).Decompile();
+            LambdaExpression decompiled = (LambdaExpression)DecompileExpressionVisitor.Decompile(((Delegate)((object)compiled)).Decompile());
 
             var x1 = expected1.Body.ToString();
             Console.WriteLine(x1);

--- a/src/DelegateDecompiler.Tests/Issue135.cs
+++ b/src/DelegateDecompiler.Tests/Issue135.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NUnit.Framework;
+
+namespace DelegateDecompiler.Tests
+{
+    [TestFixture]
+    public class Issue135 : DecompilerTestsBase
+    {
+        public class Post {
+            public bool IsActive { get; set; }
+        }
+
+        public class Blog
+        {
+            public bool HasBar { get; }
+            public bool HasBaz { get; }
+
+            public IEnumerable<Post> Posts { get; }
+
+
+            [Decompile]
+            public bool HasFoo
+            {
+                get
+                {
+                    return (this.HasBar || this.HasBaz) && this.Posts.Any(x => x.IsActive);
+                }
+            }
+
+            [Decompile]
+            public bool HasFoo2
+            {
+                get
+                {
+                    return (this.HasBar && this.Posts.Any(x => x.IsActive)) || (this.HasBaz && this.Posts.Any(x => x.IsActive)) ;
+                }
+            }
+
+            [Decompile]
+            public bool HasFoo3
+            {
+                get
+                {
+                    return this.Posts.Any(x => x.IsActive) && (this.HasBar || this.HasBaz);
+                }
+            }
+        }
+
+
+        [Test, Ignore("Difference in debugView is expected")]
+        public void Test()
+        {
+            Expression<Func<Blog, bool>> expected = b => b.HasBar ? b.Posts.Any(x => x.IsActive) : (b.HasBaz && b.Posts.Any(x => x.IsActive));
+            Func<Blog, bool> compiled = b => b.HasFoo;
+
+            Test(expected, compiled);
+        }
+
+        [Test]
+        public void Test2()
+        {
+            Expression<Func<Blog, bool>> expected = b => b.Posts.Any(x => x.IsActive) && (b.HasBar ? true : b.HasBaz);
+            Func<Blog, bool> compiled = b => b.HasFoo3;
+
+            Test(expected, compiled);
+        }
+    }
+}

--- a/src/DelegateDecompiler/ExpressionHelper.cs
+++ b/src/DelegateDecompiler/ExpressionHelper.cs
@@ -5,9 +5,9 @@ namespace DelegateDecompiler
 {
     internal static class ExpressionHelper
     {
-        internal static Expression Default(Type type) =>
+        internal static Expression Default(Type type, object defaultValue) =>
             // LINQ to entities and possibly other providers don't support Expression.Default, so this gets the default
             // value and then uses an Expression.Constant instead
-            Expression.Constant(type.IsValueType ? Activator.CreateInstance(type) : null, type);
+            Expression.Constant(defaultValue ?? (type.IsValueType ? Activator.CreateInstance(type) : null), type);
     }
 }

--- a/src/DelegateDecompiler/MethodBodyDecompiler.cs
+++ b/src/DelegateDecompiler/MethodBodyDecompiler.cs
@@ -138,7 +138,7 @@ namespace DelegateDecompiler
                 }
             }
 
-            return ExpressionHelper.Default(method.ReturnType);
+            return ExpressionHelper.Default(method.ReturnType, null);
         }
 
         static MethodInfo GetDeclaredMethod(Type type, MethodInfo method)

--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -362,7 +362,7 @@ namespace DelegateDecompiler
                     else if (state.Instruction.OpCode == OpCodes.Brfalse ||
                              state.Instruction.OpCode == OpCodes.Brfalse_S)
                     {
-                        state.Instruction = ConditionalBranch(state, val => Expression.Equal(val, ExpressionHelper.Default(val.Type)));
+                        state.Instruction = ConditionalBranch(state, val => Expression.Equal(val, ExpressionHelper.Default(val.Type, null)));
                         continue;
                     }
                     else if (state.Instruction.OpCode == OpCodes.Brtrue ||
@@ -376,7 +376,7 @@ namespace DelegateDecompiler
                         }
                         else
                         {
-                            state.Instruction = ConditionalBranch(state, val => val.Type == typeof(bool) ? val : Expression.NotEqual(val, ExpressionHelper.Default(val.Type)));
+                            state.Instruction = ConditionalBranch(state, val => val.Type == typeof(bool) ? val : Expression.NotEqual(val, ExpressionHelper.Default(val.Type, null)));
                             continue;
                         }
                     }
@@ -666,7 +666,7 @@ namespace DelegateDecompiler
                     {
                         var address = state.Stack.Pop();
                         var type = (Type) state.Instruction.Operand;
-                        address.Expression = ExpressionHelper.Default(type);
+                        address.Expression = ExpressionHelper.Default(type, null);
                     }
                     else if (state.Instruction.OpCode == OpCodes.Newarr)
                     {


### PR DESCRIPTION
While testing and debugging, the update of output documentation is annoying when working on multiple branches, from a developper POV.