### PR TITLE
Fix Queryable Include & AsNoTracking extensions for EF

### DIFF
--- a/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Abstracts/Animal.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Abstracts/Animal.cs
@@ -2,6 +2,8 @@
 {
     public abstract class Animal : LivingBeeing
     {
+        public Person Owner { get; set; }
+
         [Computed]
         public abstract bool IsPet { get; }
     }

--- a/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Abstracts/Cat.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Abstracts/Cat.cs
@@ -1,0 +1,12 @@
+﻿using System.Linq;
+
+namespace DelegateDecompiler.EntityFramework.Tests.EfItems.Abstracts
+{
+    public class Cat : Feline
+    {
+        public override string Species => base.Species + " silvestris";
+
+        public override bool IsPet => true;
+
+    }
+}

--- a/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Abstracts/Feline.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Abstracts/Feline.cs
@@ -1,0 +1,8 @@
+﻿namespace DelegateDecompiler.EntityFramework.Tests.EfItems.Abstracts
+{
+    public class Feline : Animal
+    {
+        public override string Species => "Felis";
+        public override bool IsPet => false;
+    }
+}

--- a/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Abstracts/Person.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Abstracts/Person.cs
@@ -11,6 +11,6 @@ namespace DelegateDecompiler.EntityFramework.Tests.EfItems.Abstracts
 
         public DateTime Birthdate { get; set; }
 
-        public virtual ICollection<Animal> Animals { get; set; }
+        public ICollection<Animal> Animals { get; set; }
     }
 }

--- a/src/DelegateDecompiler.EntityFramework.Tests/EfItems/DatabaseHelpers.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/EfItems/DatabaseHelpers.cs
@@ -96,10 +96,12 @@ namespace DelegateDecompiler.EntityFramework.Tests.EfItems
         {
             var animal1 = new Dog { Age = 2};
             var animal2 = new Dog { Age = 3};
+            var animal3 = new Cat { Age = 4 };
             return new List<LivingBeeing>
             {
                 animal1,
                 animal2,
+                animal3,
                 new HoneyBee(),
                 new HoneyBee(),
                 new Person {Age = 1, Birthdate = new DateTime(1900, 1, 1), Name = "Joseph"},
@@ -109,7 +111,7 @@ namespace DelegateDecompiler.EntityFramework.Tests.EfItems
                     Age = 3,
                     Birthdate = new DateTime(1900, 1, 2),
                     Name = "John Doe",
-                    Animals = new List<Animal> {animal1, animal2}
+                    Animals = new List<Animal> {animal1, animal2, animal3}
                 }
             };
         }

--- a/src/DelegateDecompiler.EntityFramework.Tests/EfItems/EfTestDbContext.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/EfItems/EfTestDbContext.cs
@@ -48,6 +48,8 @@ namespace DelegateDecompiler.EntityFramework.Tests.EfItems
                 .Computed(x => x.GetFullNameNoAttibute());
             
             modelBuilder.Entity<Dog>();
+            modelBuilder.Entity<Feline>();
+            modelBuilder.Entity<Cat>();
             modelBuilder.Entity<HoneyBee>();
             modelBuilder.Entity<Person>();
             base.OnModelCreating(modelBuilder);

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test01Select.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test01Select.cs
@@ -1,6 +1,5 @@
 ﻿// Contributed by @JonPSmith (GitHub) www.thereformedprogrammer.com
 
-using System;
 using System.Linq;
 using DelegateDecompiler.EntityFramework.Tests.EfItems.Abstracts;
 using DelegateDecompiler.EntityFramework.Tests.Helpers;

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test01Select.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test01Select.cs
@@ -1,5 +1,6 @@
 ﻿// Contributed by @JonPSmith (GitHub) www.thereformedprogrammer.com
 
+using System;
 using System.Linq;
 using DelegateDecompiler.EntityFramework.Tests.EfItems.Abstracts;
 using DelegateDecompiler.EntityFramework.Tests.Helpers;
@@ -148,7 +149,7 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
 
                 //ATTEMPT
                 env.AboutToUseDelegateDecompiler();
-                var dd = env.Db.LivingBeeing.OfType<Animal>().Select(p => p.Species + " : " + p.IsPet).Decompile().ToList();
+                var dd = env.Db.LivingBeeing.OfType<Animal>().Select(p => p.Species + " : " + (p.IsPet ? Boolean.TrueString : Boolean.FalseString)).Decompile().ToList();
 
                 //VERIFY
                 env.CompareAndLogList(linq, dd);

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test05Where.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test05Where.cs
@@ -1,5 +1,6 @@
 ﻿// Contributed by @JonPSmith (GitHub) www.thereformedprogrammer.com
 
+using System;
 using System.Linq;
 using DelegateDecompiler.EntityFramework.Tests.EfItems.Abstracts;
 using DelegateDecompiler.EntityFramework.Tests.Helpers;
@@ -97,7 +98,7 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
 
                 //ATTEMPT
                 env.AboutToUseDelegateDecompiler();
-                var dd = env.Db.LivingBeeing.OfType<Animal>().Where(p => p.Species + " : " + p.IsPet == "Apis mellifera : False").Select(x => x.Id).Decompile().ToList();
+                var dd = env.Db.LivingBeeing.OfType<Animal>().Where(p => p.Species + " : " + (p.IsPet ? Boolean.TrueString : Boolean.FalseString) == "Apis mellifera : False").Select(x => x.Id).Decompile().ToList();
 
                 //VERIFY
                 env.CompareAndLogList(linq, dd);

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup13QueryableExtensions/Test01InCludeAndAsNoTracking.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup13QueryableExtensions/Test01InCludeAndAsNoTracking.cs
@@ -27,8 +27,22 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup13QueryableExtension
             {
                 //ATTEMPT
                 env.AboutToUseDelegateDecompiler();
-                var dd = env.Db.LivingBeeing.Decompile().OfType<Animal>().Include(lb => lb.Owner).ToList();
-                Assert.IsTrue(dd.Any(a => a.Owner != null));
+                var dd = env.Db.LivingBeeing.Decompile().OfType<Dog>().Include(lb => lb.Owner).ToList();
+                Assert.IsNotNull(dd.First().Owner);
+                Assert.AreEqual(2, dd.First().Owner.Animals.Count);
+            }
+        }
+
+        [Test]
+        public void TestDecompileSequencingForMultipleInclude()
+        {
+            using (var env = new MethodEnvironment(classEnv))
+            {
+                //ATTEMPT
+                env.AboutToUseDelegateDecompiler();
+                var dd = env.Db.LivingBeeing.Decompile().OfType<Dog>().Include(lb => lb.Owner).Include(lb => lb.Owner.Animals).ToList();
+                Assert.IsNotNull(dd.First().Owner);
+                Assert.AreEqual(3, dd.First().Owner.Animals.Count);
             }
         }
 
@@ -39,7 +53,7 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup13QueryableExtension
             {
                 //ATTEMPT
                 env.AboutToUseDelegateDecompiler();
-                var dd = env.Db.LivingBeeing.Decompile().AsNoTracking().OfType<Animal>().Include(lb => lb.Owner).ToList();
+                var dd = env.Db.LivingBeeing.Decompile().AsNoTracking().OfType<Animal>().ToList();
                 Assert.IsTrue(dd.All(a => env.Db.Entry(a).State == EntityState.Detached));
             }
         }

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup13QueryableExtensions/Test01InCludeAndAsNoTracking.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup13QueryableExtensions/Test01InCludeAndAsNoTracking.cs
@@ -1,0 +1,49 @@
+﻿// Contributed by @magicmoux (GitHub)
+#if !EF_CORE
+
+using System;
+using System.Data.Entity;
+using System.Linq;
+using DelegateDecompiler.EntityFramework.Tests.EfItems.Abstracts;
+using DelegateDecompiler.EntityFramework.Tests.Helpers;
+using NUnit.Framework;
+
+namespace DelegateDecompiler.EntityFramework.Tests.TestGroup13QueryableExtensions
+{
+    class Test01IncludeAndAsNoTracking
+    {
+        private ClassEnvironment classEnv;
+
+        [OneTimeSetUp]
+        public void SetUpFixture()
+        {
+            classEnv = new ClassEnvironment();
+        }
+
+        [Test]
+        public void TestDecompileSequencingForInclude()
+        {
+            using (var env = new MethodEnvironment(classEnv))
+            {
+                //ATTEMPT
+                env.AboutToUseDelegateDecompiler();
+                var dd = env.Db.LivingBeeing.Decompile().OfType<Animal>().Include(lb => lb.Owner).ToList();
+                Assert.IsTrue(dd.Any(a => a.Owner != null));
+            }
+        }
+
+        [Test]
+        public void TestDecompileSequencingForAsNoTracking()
+        {
+            using (var env = new MethodEnvironment(classEnv))
+            {
+                //ATTEMPT
+                env.AboutToUseDelegateDecompiler();
+                var dd = env.Db.LivingBeeing.Decompile().AsNoTracking().OfType<Animal>().Include(lb => lb.Owner).ToList();
+                Assert.IsTrue(dd.All(a => env.Db.Entry(a).State == EntityState.Detached));
+            }
+        }
+    }
+}
+
+#endif

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup99SaveResults/Test99SaveResults.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup99SaveResults/Test99SaveResults.cs
@@ -9,9 +9,11 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup99SaveResults
         [Test]
         public void EndRun()
         {
+#if !DEBUG
             MasterEnvironment.UpdateDocumentationIfLooksLikeAFullRun();
             //var markupResults = MasterEnvironment.ResultsAsMarkup( OutputVersions.Summary);
             //Console.Write(markupResults);
+#endif
         }
 
     }

--- a/src/DelegateDecompiler.EntityFramework/DecompileExtensions.cs
+++ b/src/DelegateDecompiler.EntityFramework/DecompileExtensions.cs
@@ -4,9 +4,17 @@ namespace DelegateDecompiler.EntityFramework
 {
     public static class DecompileExtensions
     {
+        public static IQueryable<T> Decompile<T>(this IQueryable<T> self)
+        {
+            // Minor optimisation : avoid stacking multiple instances when chaining multiple calls to Decompile
+            var provider = self.Provider;
+            if (!(provider is EfDecompiledQueryProvider)) provider = new EfDecompiledQueryProvider(self.Provider);
+            return provider.CreateQuery<T>(self.Expression);
+        }
+
         public static IQueryable<T> DecompileAsync<T>(this IQueryable<T> self)
         {
-            return new AsyncDecompiledQueryProvider(self.Provider).CreateQuery<T>(self.Expression);
+            return Decompile<T>(self);
         }
     }
 }

--- a/src/DelegateDecompiler.EntityFramework/EfDecompiledQueryProvider.cs
+++ b/src/DelegateDecompiler.EntityFramework/EfDecompiledQueryProvider.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Entity.Infrastructure;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DelegateDecompiler.EntityFramework
+{
+    public class EfDecompiledQueryProvider : DecompiledQueryProvider, IDbAsyncQueryProvider
+    {
+        private static readonly MethodInfo openGenericCreateQueryMethod =
+            typeof(EfDecompiledQueryProvider)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Single(method => method.Name == "CreateQuery" && method.IsGenericMethod);
+
+        protected internal EfDecompiledQueryProvider(IQueryProvider inner)
+            : base(inner)
+        {
+        }
+
+        public override IQueryable CreateQuery(Expression expression)
+        {
+            Type elementType = expression.Type
+                .GetInterfaces()
+                .Where(type => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                .Select(type => type.GetGenericArguments().FirstOrDefault())
+                .FirstOrDefault();
+
+            if (elementType == null)
+            {
+                throw new ArgumentException();
+            }
+
+            MethodInfo closedGenericCreateQueryMethod = openGenericCreateQueryMethod.MakeGenericMethod(elementType);
+
+            return (IQueryable)closedGenericCreateQueryMethod.Invoke(this, new object[] { expression });
+        }
+
+        public override IQueryable<TElement> CreateQuery<TElement>(Expression expression)
+        {
+            var decompiled = new DecompileExpressionVisitor().Visit(expression);
+            return new EfDecompiledQueryable<TElement>(this, inner.CreateQuery<TElement>(decompiled));
+        }
+
+        public Task<object> ExecuteAsync(Expression expression, CancellationToken cancellationToken)
+        {
+            IDbAsyncQueryProvider asyncProvider = inner as IDbAsyncQueryProvider;
+            if (asyncProvider == null)
+            {
+                throw new InvalidOperationException("The source IQueryProvider doesn't implement IDbAsyncQueryProvider.");
+            }
+            var decompiled = new DecompileExpressionVisitor().Visit(expression);
+            return asyncProvider.ExecuteAsync(decompiled, cancellationToken);
+        }
+
+        public Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
+        {
+            IDbAsyncQueryProvider asyncProvider = inner as IDbAsyncQueryProvider;
+            if (asyncProvider == null)
+            {
+                throw new InvalidOperationException("The source IQueryProvider doesn't implement IDbAsyncQueryProvider.");
+            }
+            var decompiled = new DecompileExpressionVisitor().Visit(expression);
+            return asyncProvider.ExecuteAsync<TResult>(decompiled, cancellationToken);
+        }
+    }
+}

--- a/src/DelegateDecompiler.EntityFramework/EfDecompiledQueryable.cs
+++ b/src/DelegateDecompiler.EntityFramework/EfDecompiledQueryable.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace DelegateDecompiler.EntityFramework
+{
+    internal class EfDecompiledQueryable<T>
+        : DecompiledQueryable<T>, IDbAsyncEnumerable<T>, IEnumerable
+    {
+        protected internal EfDecompiledQueryable(IQueryProvider provider, IQueryable<T> inner)
+            : base(provider, inner)
+        {
+        }
+
+        IDbAsyncEnumerator IDbAsyncEnumerable.GetAsyncEnumerator()
+        {
+            return GetAsyncEnumerator();
+        }
+
+        public IDbAsyncEnumerator<T> GetAsyncEnumerator()
+        {
+            IDbAsyncEnumerable<T> asyncEnumerable = inner as IDbAsyncEnumerable<T>;
+            if (asyncEnumerable == null)
+            {
+                throw new InvalidOperationException("The source IQueryable doesn't implement IDbAsyncEnumerable<T>.");
+            }
+            return asyncEnumerable.GetAsyncEnumerator();
+        }
+
+        #region EF-Linq overrides
+
+        //TODO complete all EntityFramework-sepcific Linq methods : AsStreaming...
+
+        public IQueryable<T> Include<TProperty>(Expression<Func<T, TProperty>> path)
+        {
+            //TODO See whether the path should be decompiled and materialize result with a projection
+            return inner.Include(path).Decompile();
+        }
+
+        public virtual IQueryable<T> Include(string path)
+        {
+            //TODO See whether the path should be decompiled and materialize result with a projection
+            return inner.Include(path).Decompile();
+        }
+
+        public virtual IQueryable<T> AsNoTracking()
+        {
+            return ((IQueryable<T>)((IQueryable)inner).AsNoTracking()).Decompile();
+        }
+
+        #endregion
+    }
+}

--- a/src/DelegateDecompiler/DecompiledQueryProvider.cs
+++ b/src/DelegateDecompiler/DecompiledQueryProvider.cs
@@ -12,7 +12,7 @@ namespace DelegateDecompiler
             typeof(DecompiledQueryProvider)
             .GetMethods(BindingFlags.Public | BindingFlags.Instance)
             .Single(method => method.Name == "CreateQuery" && method.IsGenericMethod);
-        readonly IQueryProvider inner;
+        protected readonly IQueryProvider inner;
 
         protected internal DecompiledQueryProvider(IQueryProvider inner)
         {

--- a/src/DelegateDecompiler/DecompiledQueryable.cs
+++ b/src/DelegateDecompiler/DecompiledQueryable.cs
@@ -8,7 +8,7 @@ namespace DelegateDecompiler
 {
     public class DecompiledQueryable<T> : IOrderedQueryable<T>
     {
-        private readonly IQueryable<T> inner;
+        protected readonly IQueryable<T> inner;
         private readonly IQueryProvider provider;
 
         protected internal DecompiledQueryable(IQueryProvider provider, IQueryable<T> inner)


### PR DESCRIPTION
Hi @hazzik,

Here is a potential solution for dealing call order to the Decompile method for Include and AsNoTracking EF extensions on .NET 4.x.

If the implementation is acceptable, it would allow to close #38 Issue and #53 PR

Thanks in advance for your review,
Max.