### PR TITLE
Fix issue135

### DIFF
--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup99SaveResults/Test99SaveResults.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup99SaveResults/Test99SaveResults.cs
@@ -9,9 +9,11 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup99SaveResults
         [Test]
         public void EndRun()
         {
+#if !DEBUG
             MasterEnvironment.UpdateDocumentationIfLooksLikeAFullRun();
             //var markupResults = MasterEnvironment.ResultsAsMarkup( OutputVersions.Summary);
             //Console.Write(markupResults);
+#endif
         }
 
     }

--- a/src/DelegateDecompiler.Tests/DecompilerTestsBase.cs
+++ b/src/DelegateDecompiler.Tests/DecompilerTestsBase.cs
@@ -18,7 +18,8 @@ namespace DelegateDecompiler.Tests
         protected static void Test<T>(Expression<T> expected, T compiled)
         {
             //Double cast required as we can not convert T to Delegate directly
-            var decompiled = ((Delegate) ((object) compiled)).Decompile();
+            //var decompiled = ((Delegate)((object)compiled)).Decompile();
+            var decompiled = (LambdaExpression)DecompileExpressionVisitor.Decompile(((Delegate) ((object) compiled)).Decompile());
 
             var x = expected.Body.ToString();
             Console.WriteLine(x);
@@ -31,7 +32,8 @@ namespace DelegateDecompiler.Tests
         protected static void Test<T>(Expression<T> expected, MethodInfo compiled)
         {
             //Double cast required as we can not convert T to Delegate directly
-            var decompiled = compiled.Decompile();
+            //var decompiled = compiled.Decompile();
+            var decompiled = (LambdaExpression)DecompileExpressionVisitor.Decompile(compiled.Decompile());
 
             var x = expected.Body.ToString();
             Console.WriteLine(x);
@@ -44,7 +46,8 @@ namespace DelegateDecompiler.Tests
         protected static void Test<T>(Expression<T> expected1, Expression<T> expected2, T compiled)
         {
             //Double cast required as we can not convert T to Delegate directly
-            var decompiled = ((Delegate) ((object) compiled)).Decompile();
+            //var decompiled = ((Delegate) ((object) compiled)).Decompile();
+            LambdaExpression decompiled = (LambdaExpression)DecompileExpressionVisitor.Decompile(((Delegate)((object)compiled)).Decompile());
 
             var x1 = expected1.Body.ToString();
             Console.WriteLine(x1);

--- a/src/DelegateDecompiler.Tests/Issue135.cs
+++ b/src/DelegateDecompiler.Tests/Issue135.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NUnit.Framework;
+
+namespace DelegateDecompiler.Tests
+{
+    [TestFixture]
+    public class Issue135 : DecompilerTestsBase
+    {
+        public class Post {
+            public bool IsActive { get; set; }
+        }
+
+        public class Blog
+        {
+            public bool HasBar { get; }
+            public bool HasBaz { get; }
+
+            public IEnumerable<Post> Posts { get; }
+
+
+            [Decompile]
+            public bool HasFoo
+            {
+                get
+                {
+                    return (this.HasBar || this.HasBaz) && this.Posts.Any(x => x.IsActive);
+                }
+            }
+
+            [Decompile]
+            public bool HasFoo2
+            {
+                get
+                {
+                    return (this.HasBar && this.Posts.Any(x => x.IsActive)) || (this.HasBaz && this.Posts.Any(x => x.IsActive)) ;
+                }
+            }
+
+            [Decompile]
+            public bool HasFoo3
+            {
+                get
+                {
+                    return this.Posts.Any(x => x.IsActive) && (this.HasBar || this.HasBaz);
+                }
+            }
+        }
+
+
+        [Test]
+        public void Test()
+        {
+            Expression<Func<Blog, bool>> expected = b => b.HasBar ? b.Posts.Any(x => x.IsActive) : (b.HasBaz && b.Posts.Any(x => x.IsActive));
+            Func<Blog, bool> compiled = b => b.HasFoo;
+
+            Test(expected, compiled);
+        }
+
+        [Test]
+        public void Test2()
+        {
+            Expression<Func<Blog, bool>> expected = b => b.Posts.Any(x => x.IsActive) && (b.HasBar ? true : b.HasBaz);
+            Func<Blog, bool> compiled = b => b.HasFoo3;
+
+            Test(expected, compiled);
+        }
+    }
+}

--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -376,7 +376,7 @@ namespace DelegateDecompiler
                         }
                         else
                         {
-                            state.Instruction = ConditionalBranch(state, val => val.Type == typeof(bool) ? val : Expression.NotEqual(val, ExpressionHelper.Default(val.Type)));
+                            state.Instruction = ConditionalBranch(state, val => (val as LambdaExpression)?.ReturnType == typeof(bool) || val.Type == typeof(bool) ? val : Expression.NotEqual(val, ExpressionHelper.Default(val.Type)));
                             continue;
                         }
                     }
@@ -847,20 +847,21 @@ namespace DelegateDecompiler
         {
             var val1 = state.Stack.Pop();
             var test = condition(val1);
-
-            var left = (Instruction) state.Instruction.Operand;
-            var right = state.Instruction.Next;
-
             var common = GetJointPoint(state.Instruction);
+            if (!(test is LambdaExpression))
+            {
 
-            var rightState = state.Clone(right, common);
-            var leftState = state.Clone(left, common);
-            states.Push(rightState);
-            states.Push(leftState);
+                var left = (Instruction)state.Instruction.Operand;
+                var right = state.Instruction.Next;
 
-            // Run this once the conditional branches have been processed
-            state.RunNext = () => state.Merge(test, leftState, rightState);
+                var rightState = state.Clone(right, common);
+                var leftState = state.Clone(left, common);
+                states.Push(rightState);
+                states.Push(leftState);
 
+                // Run this once the conditional branches have been processed
+                state.RunNext = () => state.Merge(test, leftState, rightState);
+            }
             return common;
         }
 


### PR DESCRIPTION
hi @hazzik 

I had a look on this one.
I think the issue comes from overlooking the Processor's `OpCodes.Brtrue/Brtrue_S` where the instruction is a `LambdaExpression` returning a bool.

Here is just a PR to show the solution I found for issue #135, but I'm not sure it is exhaustive or not.
Anyway it does not seem to introduce tests regression so far.

The first test's failure is expected due to difference between both expressions' debugView
