### PR TITLE
Multi-target DelegateDecompiler.EntityFramework to netstandard 2.1

### DIFF
--- a/src/DelegateDecompiler.EntityFramework/DelegateDecompiler.EntityFramework.csproj
+++ b/src/DelegateDecompiler.EntityFramework/DelegateDecompiler.EntityFramework.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
     <Copyright>Copyright © Dave Glick 2014, Jon Smith 2014, Alexander Zaytsev 2014 - 2019</Copyright>
     <PackageTags>$(PackageTags) EF EntityFramework Entity-Framework</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
Currently any new project (built w/ netcore 3.0) referencing this project will receive a warning indicating the assembly was built to target .net framework 4.5

This change allows them to target netstandard 2.1