### PR TITLE
Fix unary Not operator for enums

### DIFF
--- a/src/DelegateDecompiler.Tests/EnumTests.cs
+++ b/src/DelegateDecompiler.Tests/EnumTests.cs
@@ -132,6 +132,14 @@ namespace DelegateDecompiler.Tests
         }
 
         [Test]
+        public void TestNotEnumParameter()
+        {
+            Expression<Func<TestFlagEnum, TestFlagEnum>> expected = x => ~ x;
+            Func<TestFlagEnum, TestFlagEnum> compiled = x => ~ x;
+            Test(expected, compiled);
+        }
+
+        [Test]
         public void TestEnumParameterAndEnumParameter()
         {
             Expression<Func<TestFlagEnum, TestFlagEnum>> expected = x => x & x;

--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -523,7 +523,7 @@ namespace DelegateDecompiler
                     else if (state.Instruction.OpCode == OpCodes.Not)
                     {
                         var val = state.Stack.Pop();
-                        state.Stack.Push(Expression.Not(val));
+                        state.Stack.Push(MakeUnaryExpression(val, ExpressionType.Not));
                     }
                     else if (state.Instruction.OpCode == OpCodes.Conv_I)
                     {
@@ -829,6 +829,13 @@ namespace DelegateDecompiler
             right = ConvertEnumExpressionToUnderlyingType(right);
 
             return Expression.MakeBinary(expressionType, left, right);
+        }
+
+        static UnaryExpression MakeUnaryExpression(Expression operand, ExpressionType expressionType)
+        {
+            operand = ConvertEnumExpressionToUnderlyingType(operand);
+
+            return Expression.MakeUnary(expressionType, operand, operand.Type);
         }
 
         static Expression Box(Expression expression, Type type)


### PR DESCRIPTION
Using same technique as binary expressions (created MakeUnaryExpression based on MakeBinaryExpression).

Fixes #168 