### PR TITLE
Add IsByRef check in AdjustType

### DIFF
--- a/src/DelegateDecompiler/Processor.cs
+++ b/src/DelegateDecompiler/Processor.cs
@@ -933,7 +933,7 @@ namespace DelegateDecompiler
 
         internal static Expression AdjustType(Expression expression, Type type)
         {
-            if (expression.Type == type)
+            if (expression.Type == type || type.IsByRef)
             {
                 return expression;
             }


### PR DESCRIPTION
Fix for #172 

With this change `dotnet dotcover test` runs successfully!

Have fiddled around with trying to get a test for it but not 100% sure how to approach it.