### PR TITLE
Adding Decompile extension methods for non-generic IQueryable (#177)

### DIFF
--- a/src/DelegateDecompiler.EntityFramework.Tests/Helpers/CheckerAndLogger.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/Helpers/CheckerAndLogger.cs
@@ -1,6 +1,7 @@
 ﻿// Contributed by @JonPSmith (GitHub) www.thereformedprogrammer.com
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -25,7 +26,25 @@ namespace DelegateDecompiler.EntityFramework.Tests.Helpers
                 env.LogFailer(sourceLineNumber);
                 throw;
             }
-            env.LogSuccess(sourceLineNumber);  
+            env.LogSuccess(sourceLineNumber);
+        }
+
+        public static void CompareAndLogNonGenericList(this MethodEnvironment env, IList linqResult, IList ddResult,
+            [CallerLineNumber] int sourceLineNumber = 0)
+        {
+            if (linqResult.Count == 0)
+                throw new ArgumentException("The linq result was empty, so this was not a fair test.");
+
+            try
+            {
+                CollectionAssert.AreEqual(linqResult, ddResult);
+            }
+            catch (Exception)
+            {
+                env.LogFailer(sourceLineNumber);
+                throw;
+            }
+            env.LogSuccess(sourceLineNumber);
         }
 
         public static void CompareAndLogSingleton<T>(this MethodEnvironment env, T linqResult, T ddResult,

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test02SelectAsync.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test02SelectAsync.cs
@@ -40,6 +40,25 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
             }
         }
 
+#if !EF_CORE
+        [Test]
+        public async Task TestAsyncNonGeneric()
+        {
+            using (var env = new MethodEnvironment(classEnv))
+            {
+                //SETUP
+                var linq = await env.Db.EfParents.ToListAsync();
+
+                //ATTEMPT
+                env.AboutToUseDelegateDecompiler();
+                var dd = await ((IQueryable)env.Db.EfParents).DecompileAsync().ToListAsync();
+
+                //VERIFY
+                env.CompareAndLogNonGenericList(linq, dd);
+            }
+        }
+#endif
+
         [Test]
         public async Task TestBoolEqualsConstantAsync()
         {

--- a/src/DelegateDecompiler.EntityFramework/DecompileExtensions.cs
+++ b/src/DelegateDecompiler.EntityFramework/DecompileExtensions.cs
@@ -8,5 +8,10 @@ namespace DelegateDecompiler.EntityFramework
         {
             return new AsyncDecompiledQueryProvider(self.Provider).CreateQuery<T>(self.Expression);
         }
+
+        public static IQueryable DecompileAsync(this IQueryable self)
+        {
+            return new AsyncDecompiledQueryProvider(self.Provider).CreateQuery(self.Expression);
+        }
     }
 }

--- a/src/DelegateDecompiler.Tests/QueryableExtensionsTests.cs
+++ b/src/DelegateDecompiler.Tests/QueryableExtensionsTests.cs
@@ -40,6 +40,22 @@ namespace DelegateDecompiler.Tests
         }
 
         [Test]
+        public void InlinePropertyNonGeneric()
+        {
+            var employees = new[] { new Employee { FirstName = "Test", LastName = "User" } };
+
+            var expected = (from employee in employees.AsQueryable()
+                            where (employee.FirstName + " " + employee.LastName) == "Test User"
+                            select employee);
+
+            var actual = ((IQueryable)(from employee in employees.AsQueryable()
+                          where employee.FullName == "Test User"
+                          select employee)).Decompile();
+
+            AssertAreEqual(expected.Expression, actual.Expression);
+        }
+
+        [Test]
         public void ConcatNonStringInlineProperty()
         {
             var employees = new[] { new Employee { FirstName = "Test", LastName = "User", From = 0, To = 100 } };

--- a/src/DelegateDecompiler/DecompileExtensions.cs
+++ b/src/DelegateDecompiler/DecompileExtensions.cs
@@ -43,5 +43,11 @@ namespace DelegateDecompiler
             var provider = new DecompiledQueryProvider(self.Provider);
             return provider.CreateQuery<T>(self.Expression);
         }
+
+        public static IQueryable Decompile(this IQueryable self)
+        {
+            var provider = new DecompiledQueryProvider(self.Provider);
+            return provider.CreateQuery(self.Expression);
+        }
     }
 }


### PR DESCRIPTION
Hi, 
This resolves #177.
I'm trying to use the Decompile extension with a class defined at runtime using the [TypeBuilder](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.typebuilder?view=netframework-4.7.2). This means I only have a non-generic IQueryable type. As mentioned in issue #177 there are no non-generic Decompile extension methods. I could call the generic one at runtime using reflection but the code to do that is already in the DecompiledQueryProvider, it's just not accessible without the non-generic Decompile extension method, so I've added it and a couple of tests. I didn't go particularly crazy on the tests because the non-generic CreateQuery just calls the generic one. 
Thanks,
Richard