### PR TITLE
Fix issue with uwrapped Parameters

### DIFF
--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Tuesday, 14 December 2021 22:20
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).
@@ -141,6 +141,12 @@ More will appear as we move forward.*
 #### [DateTime](../TestGroup50Types/Test05DateTime.cs):
 - Supported
   * DateTime Where Compare With Static Variable (line 35)
+
+
+### Group: Additional Features
+#### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
+- **Not Supported**
+  * Subquery As Context Extension Method (line 59)
 
 
 

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 16:12
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).
@@ -145,8 +145,8 @@ More will appear as we move forward.*
 
 ### Group: Additional Features
 #### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
-- **Not Supported**
-  * Subquery As Context Extension Method (line 59)
+- Supported
+  * Subquery As Context Extension Method (line 68)
 
 
 

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Tuesday, 14 December 2021 22:20
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).
@@ -830,6 +830,12 @@ SELECT
     WHERE [Extent1].[StartDate] > @p__linq__0
 ```
 
+
+
+### Group: Additional Features
+#### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
+- **Not Supported**
+  * Subquery As Context Extension Method (line 59)
 
 
 

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 16:12
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).
@@ -834,8 +834,32 @@ SELECT
 
 ### Group: Additional Features
 #### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
-- **Not Supported**
-  * Subquery As Context Extension Method (line 59)
+- Supported
+  * Subquery As Context Extension Method (line 68)
+     * T-Sql executed is
+
+```SQL
+SELECT 
+    [Project4].[EfParentId] AS [EfParentId], 
+    CASE WHEN ([Project4].[C1] IS NULL) THEN 0 ELSE [Project4].[C2] END AS [C1]
+    FROM ( SELECT 
+        [Project2].[EfParentId] AS [EfParentId], 
+        [Project2].[C1] AS [C1], 
+        (SELECT TOP (1) 
+            [Extent3].[EfChildId] AS [EfChildId]
+            FROM [dbo].[EfChilds] AS [Extent3]
+            WHERE [Extent3].[EfParentId] = [Project2].[EfParentId]) AS [C2]
+        FROM ( SELECT 
+            [Extent1].[EfParentId] AS [EfParentId], 
+            (SELECT TOP (1) 
+                [Extent2].[EfChildId] AS [EfChildId]
+                FROM [dbo].[EfChilds] AS [Extent2]
+                WHERE [Extent2].[EfParentId] = [Extent1].[EfParentId]) AS [C1]
+            FROM [dbo].[EfParents] AS [Extent1]
+        )  AS [Project2]
+    )  AS [Project4]
+```
+
 
 
 

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 16:12
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).
@@ -55,7 +55,7 @@ More will appear as we move forward.*
   * [DateTime](../TestGroup50Types/Test05DateTime.cs) (1 tests)
 
 ### Group: Additional Features
-- **Not Supported**
+- Supported
   * [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs) (1 tests)
 
 

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Tuesday, 14 December 2021 22:20
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).
@@ -53,6 +53,10 @@ More will appear as we move forward.*
 - Supported
   * [Strings](../TestGroup50Types/Test01Strings.cs) (4 tests)
   * [DateTime](../TestGroup50Types/Test05DateTime.cs) (1 tests)
+
+### Group: Additional Features
+- **Not Supported**
+  * [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs) (1 tests)
 
 
 The End

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup90AdditionalFeatures/Test01Issue152.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup90AdditionalFeatures/Test01Issue152.cs
@@ -1,0 +1,74 @@
+﻿using System.Linq;
+using System.Net.Mail;
+using DelegateDecompiler.EntityFramework.Tests.EfItems;
+using DelegateDecompiler.EntityFramework.Tests.EfItems.Abstracts;
+using DelegateDecompiler.EntityFramework.Tests.Helpers;
+using NUnit.Framework;
+
+namespace DelegateDecompiler.EntityFramework.Tests.TestGroup90AdditionalFeatures
+{
+    public static class EfTestDbContextExtensions
+    {
+        [Computed]
+        public static int GetFirstChildIdByParent(this EfTestDbContext context, int parentId)
+        {
+            return context.EfChildren.Where(e => e.EfParentId == parentId).Select(e => e.EfChildId).FirstOrDefault();
+        }
+    }
+
+    class Test01Issue152
+    {
+        private ClassEnvironment classEnv;
+
+        [OneTimeSetUp]
+        public void SetUpFixture()
+        {
+            classEnv = new ClassEnvironment();
+        }
+
+        class ParentIdWithFirstChildId
+        {
+            public int ParentId { get; set; }
+            public int FirstChildId { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                return (obj as ParentIdWithFirstChildId)?.ParentId == ParentId && (obj as ParentIdWithFirstChildId)?.FirstChildId == FirstChildId;
+            }
+
+            public override int GetHashCode()
+            {
+                return ParentId * 131 + FirstChildId;
+            }
+        }
+
+        [Test]
+#if EF_CORE && !EF_CORE3 && !EF_CORE5
+        [Ignore("Not natively supported in EF_CORE < 3")]
+#endif
+        public void TestSubqueryAsContextExtensionMethod()
+        {
+            using (var env = new MethodEnvironment(classEnv))
+            {
+                //SETUP
+                var linq = env.Db.EfParents.Select(x => new ParentIdWithFirstChildId()
+                {
+                    ParentId = x.EfParentId,
+                    FirstChildId = env.Db.EfChildren.Where(e => e.EfParentId == x.EfParentId).Select(e => e.EfChildId).FirstOrDefault()
+                }).ToList();
+
+                //ATTEMPT
+                env.AboutToUseDelegateDecompiler();
+                var query = env.Db.EfParents.Select(x => new ParentIdWithFirstChildId()
+                {
+                    ParentId = x.EfParentId,
+                    FirstChildId = env.Db.GetFirstChildIdByParent(x.EfParentId)
+                }).Decompile();
+                var dd = query.ToList();
+
+                //VERIFY
+                env.CompareAndLogList(linq, dd);
+            }
+        }
+    }
+}

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup90AdditionalFeatures/Test01NestedExpressions.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup90AdditionalFeatures/Test01NestedExpressions.cs
@@ -1,7 +1,5 @@
 ﻿using System.Linq;
-using System.Net.Mail;
 using DelegateDecompiler.EntityFramework.Tests.EfItems;
-using DelegateDecompiler.EntityFramework.Tests.EfItems.Abstracts;
 using DelegateDecompiler.EntityFramework.Tests.Helpers;
 using NUnit.Framework;
 
@@ -10,13 +8,13 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup90AdditionalFeatures
     public static class EfTestDbContextExtensions
     {
         [Computed]
-        public static int GetFirstChildIdByParent(this EfTestDbContext context, int parentId)
+        public static int GetFirstChildIdByParent(this EfTestDbContext context, int pId)
         {
-            return context.EfChildren.Where(e => e.EfParentId == parentId).Select(e => e.EfChildId).FirstOrDefault();
+            return context.EfChildren.Where(a => a.EfParentId == pId).Select(b => b.EfChildId).FirstOrDefault();
         }
     }
 
-    class Test01Issue152
+    class Test01NestedExpressions
     {
         private ClassEnvironment classEnv;
 
@@ -33,7 +31,7 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup90AdditionalFeatures
 
             public override bool Equals(object obj)
             {
-                return (obj as ParentIdWithFirstChildId)?.ParentId == ParentId && (obj as ParentIdWithFirstChildId)?.FirstChildId == FirstChildId;
+                return obj is ParentIdWithFirstChildId id && id.ParentId == ParentId && id.FirstChildId == FirstChildId;
             }
 
             public override int GetHashCode()
@@ -54,7 +52,7 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup90AdditionalFeatures
                 var linq = env.Db.EfParents.Select(x => new ParentIdWithFirstChildId()
                 {
                     ParentId = x.EfParentId,
-                    FirstChildId = env.Db.EfChildren.Where(e => e.EfParentId == x.EfParentId).Select(e => e.EfChildId).FirstOrDefault()
+                    FirstChildId = env.Db.EfChildren.Where(a => a.EfParentId == x.EfParentId).Select(b => b.EfChildId).FirstOrDefault()
                 }).ToList();
 
                 //ATTEMPT

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Tuesday, 14 December 2021 22:21
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -142,6 +142,10 @@ More will appear as we move forward.*
 #### [DateTime](../TestGroup50Types/Test05DateTime.cs):
 - Supported
   * DateTime Where Compare With Static Variable (line 35)
+
+
+### Group: Additional Features
+#### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
 
 
 

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 16:12
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 16:12
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Tuesday, 14 December 2021 22:21
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -508,6 +508,10 @@ More will appear as we move forward.*
 
 ```
 
+
+
+### Group: Additional Features
+#### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
 
 
 

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Tuesday, 14 December 2021 22:21
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -53,6 +53,8 @@ More will appear as we move forward.*
 - Supported
   * [Strings](../TestGroup50Types/Test01Strings.cs) (4 tests)
   * [DateTime](../TestGroup50Types/Test05DateTime.cs) (1 tests)
+
+### Group: Additional Features
 
 
 The End

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 16:12
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).

--- a/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:40
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 16:11
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).

--- a/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Tuesday, 14 December 2021 22:21
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:40
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -140,6 +140,12 @@ More will appear as we move forward.*
 #### [DateTime](../TestGroup50Types/Test05DateTime.cs):
 - Supported
   * DateTime Where Compare With Static Variable (line 35)
+
+
+### Group: Additional Features
+#### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
+- Supported
+  * Subquery As Context Extension Method (line 68)
 
 
 

--- a/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Tuesday, 14 December 2021 22:21
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:40
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -488,6 +488,18 @@ More will appear as we move forward.*
 #### [DateTime](../TestGroup50Types/Test05DateTime.cs):
 - Supported
   * DateTime Where Compare With Static Variable (line 35)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+
+
+### Group: Additional Features
+#### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
+- Supported
+  * Subquery As Context Extension Method (line 68)
      * T-Sql executed is
 
 ```SQL

--- a/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:40
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 16:11
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).

--- a/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:40
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 16:11
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).

--- a/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Tuesday, 14 December 2021 22:21
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:40
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -53,6 +53,10 @@ More will appear as we move forward.*
 - Supported
   * [Strings](../TestGroup50Types/Test01Strings.cs) (4 tests)
   * [DateTime](../TestGroup50Types/Test05DateTime.cs) (1 tests)
+
+### Group: Additional Features
+- Supported
+  * [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs) (1 tests)
 
 
 The End

--- a/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 16:11
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).

--- a/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Tuesday, 14 December 2021 22:21
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -140,6 +140,12 @@ More will appear as we move forward.*
 #### [DateTime](../TestGroup50Types/Test05DateTime.cs):
 - Supported
   * DateTime Where Compare With Static Variable (line 35)
+
+
+### Group: Additional Features
+#### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
+- Supported
+  * Subquery As Context Extension Method (line 68)
 
 
 

--- a/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Tuesday, 14 December 2021 22:21
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -760,6 +760,22 @@ FROM [EfPersons] AS [e]
 SELECT [e].[StartDate]
 FROM [EfParents] AS [e]
 WHERE [e].[StartDate] > '2000-01-01T00:00:00.0000000'
+```
+
+
+
+### Group: Additional Features
+#### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
+- Supported
+  * Subquery As Context Extension Method (line 68)
+     * T-Sql executed is
+
+```SQL
+SELECT [e0].[EfParentId] AS [ParentId], COALESCE((
+    SELECT TOP(1) [e].[EfChildId]
+    FROM [EfChildren] AS [e]
+    WHERE [e].[EfParentId] = [e0].[EfParentId]), 0) AS [FirstChildId]
+FROM [EfParents] AS [e0]
 ```
 
 

--- a/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 16:11
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).

--- a/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Tuesday, 14 December 2021 22:21
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -53,6 +53,10 @@ More will appear as we move forward.*
 - Supported
   * [Strings](../TestGroup50Types/Test01Strings.cs) (4 tests)
   * [DateTime](../TestGroup50Types/Test05DateTime.cs) (1 tests)
+
+### Group: Additional Features
+- Supported
+  * [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs) (1 tests)
 
 
 The End

--- a/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 15:41
+## Documentation produced for DelegateDecompiler, version 0.30.0 on Thursday, 13 October 2022 16:11
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).

--- a/src/DelegateDecompiler/OptimizeExpressionVisitor.cs
+++ b/src/DelegateDecompiler/OptimizeExpressionVisitor.cs
@@ -461,7 +461,7 @@ namespace DelegateDecompiler
             {
                 if (node.Method.Name == nameof(Expression.Constant) && 
                     node.Method.DeclaringType == typeof(Expression) &&
-                    node.Arguments[0] is ParameterExpression parameter)
+                    node.Arguments[0] is Expression parameter)
                 {
                     return Expression.Constant(parameter);
                 }

--- a/src/DelegateDecompiler/OptimizeExpressionVisitor.cs
+++ b/src/DelegateDecompiler/OptimizeExpressionVisitor.cs
@@ -51,7 +51,7 @@ namespace DelegateDecompiler
                 if (TryConvert1(test, ifTrueBinary, out result))
                     return result;
             }
-            
+
             var testBinary = test as BinaryExpression;
             var ifTrueConstant = ifTrue as ConstantExpression;
             var ifFalseConstant = ifFalse as ConstantExpression;
@@ -209,16 +209,16 @@ namespace DelegateDecompiler
 
         static Expression ConvertToNullable(Expression expression)
         {
-	        if (!expression.Type.IsValueType || expression.Type.IsNullableType()) return expression;
+            if (!expression.Type.IsValueType || expression.Type.IsNullableType()) return expression;
 
-	        var operand = expression.NodeType == ExpressionType.Convert
-		        ? ((UnaryExpression) expression).Operand
-		        : expression;
+            var operand = expression.NodeType == ExpressionType.Convert
+                ? ((UnaryExpression) expression).Operand
+                : expression;
 
-	        return Expression.Convert(operand, typeof(Nullable<>).MakeGenericType(expression.Type));
-		}
+            return Expression.Convert(operand, typeof(Nullable<>).MakeGenericType(expression.Type));
+        }
 
-		static Expression UnwrapConvertToNullable(Expression expression)
+        static Expression UnwrapConvertToNullable(Expression expression)
         {
             var unary = expression as UnaryExpression;
             if (unary != null && expression.NodeType == ExpressionType.Convert && expression.Type.IsNullableType())
@@ -233,11 +233,11 @@ namespace DelegateDecompiler
             MemberExpression memberExpression;
             if (IsHasValue(hasValue, out memberExpression))
             {
-	            expression = new GetValueOrDefaultRemover(memberExpression.Expression).Visit(getValueOrDefault);
+                expression = new GetValueOrDefaultRemover(memberExpression.Expression).Visit(getValueOrDefault);
                 if (expression != getValueOrDefault)
                     return true;
             }
-            
+
             expression = null;
             return false;
         }
@@ -252,12 +252,12 @@ namespace DelegateDecompiler
                 if (expression == callExpression.Object)
                     return true;
             }
-            
+
             expression = null;
             return false;
         }
 
-	    static bool IsHasValue(Expression expression, out MemberExpression property)
+        static bool IsHasValue(Expression expression, out MemberExpression property)
         {
             property = expression as MemberExpression;
             return property != null && property.Member.Name == "HasValue" && property.Expression != null && property.Expression.Type.IsNullableType();
@@ -324,7 +324,7 @@ namespace DelegateDecompiler
 
         protected override Expression VisitUnary(UnaryExpression node)
         {
-            if (node.NodeType == ExpressionType.Not && 
+            if (node.NodeType == ExpressionType.Not &&
                 node.Operand is BinaryExpression binary &&
                 Invert(ref binary))
             {
@@ -350,40 +350,40 @@ namespace DelegateDecompiler
             switch (expression.NodeType)
             {
                 case ExpressionType.Equal:
-                {
-                    expression = Expression.NotEqual(expression.Left, expression.Right);
-                    return true;
-                }
+                    {
+                        expression = Expression.NotEqual(expression.Left, expression.Right);
+                        return true;
+                    }
                 case ExpressionType.NotEqual:
-                {
-                    expression = Expression.Equal(expression.Left, expression.Right);
-                    return true;
-                }
+                    {
+                        expression = Expression.Equal(expression.Left, expression.Right);
+                        return true;
+                    }
                 case ExpressionType.LessThan:
-                {
-                    expression = Expression.GreaterThanOrEqual(expression.Left, expression.Right);
-                    return true;
-                }
+                    {
+                        expression = Expression.GreaterThanOrEqual(expression.Left, expression.Right);
+                        return true;
+                    }
                 case ExpressionType.LessThanOrEqual:
-                {
-                    expression = Expression.GreaterThan(expression.Left, expression.Right);
-                    return true;
-                }
+                    {
+                        expression = Expression.GreaterThan(expression.Left, expression.Right);
+                        return true;
+                    }
                 case ExpressionType.GreaterThan:
-                {
-                    expression = Expression.LessThanOrEqual(expression.Left, expression.Right);
-                    return true;
-                }
+                    {
+                        expression = Expression.LessThanOrEqual(expression.Left, expression.Right);
+                        return true;
+                    }
                 case ExpressionType.GreaterThanOrEqual:
-                {
-                    expression = Expression.LessThan(expression.Left, expression.Right);
-                    return true;
-                }
+                    {
+                        expression = Expression.LessThan(expression.Left, expression.Right);
+                        return true;
+                    }
             }
             return false;
         }
 
-        class GetValueOrDefaultRemover :ExpressionVisitor
+        class GetValueOrDefaultRemover : ExpressionVisitor
         {
             readonly Expression expected;
 
@@ -417,19 +417,19 @@ namespace DelegateDecompiler
                 return node.Update(left, conversion, right);
             }
 
-	        protected override Expression VisitUnary(UnaryExpression node)
-	        {
-		        var before = node;
-		        var operand = Visit(node.Operand);
+            protected override Expression VisitUnary(UnaryExpression node)
+            {
+                var before = node;
+                var operand = Visit(node.Operand);
 
-		        if (operand != before.Operand)
-		        {
-			        operand = ConvertToNullable(operand);
-		        }
+                if (operand != before.Operand)
+                {
+                    operand = ConvertToNullable(operand);
+                }
 
-		        return before.Update(operand);
-	        }
-		}
+                return before.Update(operand);
+            }
+        }
 
         class GetValueOrDefaultToCoalesceConverter : ExpressionVisitor
         {
@@ -446,19 +446,20 @@ namespace DelegateDecompiler
                 return base.VisitMethodCall(node);
             }
         }
-        
+
         class LinqExpressionUnwrapper : ExpressionVisitor
         {
             public static Expression Unwrap(Expression expression)
             {
                 var visit = new LinqExpressionUnwrapper().Visit(expression);
                 var func = Expression.Lambda<Func<Expression>>(visit).Compile();
-                return Expression.Quote(func());
+                var output = UnwrappedParameterMerger.Merge(func());
+                return Expression.Quote(output);
             }
 
             protected override Expression VisitMethodCall(MethodCallExpression node)
             {
-                if (node.Method.Name == nameof(Expression.Constant) && 
+                if (node.Method.Name == nameof(Expression.Constant) &&
                     node.Method.DeclaringType == typeof(Expression) &&
                     node.Arguments[0] is Expression parameter)
                 {
@@ -466,6 +467,36 @@ namespace DelegateDecompiler
                 }
 
                 return base.VisitMethodCall(node);
+            }
+        }
+
+        class UnwrappedParameterMerger : ExpressionVisitor
+        {
+            private Dictionary<string, ParameterExpression> parameters = new Dictionary<string, ParameterExpression>();
+            private LambdaExpression lambda;
+
+            public static Expression Merge(Expression expression)
+            {
+                var resolver = new UnwrappedParameterMerger();
+                resolver.lambda = expression as LambdaExpression;
+                return resolver.Visit(resolver.lambda);
+            }
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                if (!parameters.TryGetValue(node.Name, out ParameterExpression parameter))
+                {
+                    for (var i = 0; i < lambda.Parameters.Count; i++)
+                    {
+                        if (node.Name == lambda.Parameters[i].Name)
+                        {
+                            node = lambda.Parameters[i];
+                            parameters.Add(node.Name, node);
+                            break;
+                        }
+                    }
+                }
+                return node;
             }
         }
 

--- a/src/DelegateDecompiler/OptimizeExpressionVisitor.cs
+++ b/src/DelegateDecompiler/OptimizeExpressionVisitor.cs
@@ -51,7 +51,7 @@ namespace DelegateDecompiler
                 if (TryConvert1(test, ifTrueBinary, out result))
                     return result;
             }
-
+            
             var testBinary = test as BinaryExpression;
             var ifTrueConstant = ifTrue as ConstantExpression;
             var ifFalseConstant = ifFalse as ConstantExpression;
@@ -209,16 +209,16 @@ namespace DelegateDecompiler
 
         static Expression ConvertToNullable(Expression expression)
         {
-            if (!expression.Type.IsValueType || expression.Type.IsNullableType()) return expression;
+	        if (!expression.Type.IsValueType || expression.Type.IsNullableType()) return expression;
 
-            var operand = expression.NodeType == ExpressionType.Convert
-                ? ((UnaryExpression) expression).Operand
-                : expression;
+	        var operand = expression.NodeType == ExpressionType.Convert
+		        ? ((UnaryExpression) expression).Operand
+		        : expression;
 
-            return Expression.Convert(operand, typeof(Nullable<>).MakeGenericType(expression.Type));
-        }
+	        return Expression.Convert(operand, typeof(Nullable<>).MakeGenericType(expression.Type));
+		}
 
-        static Expression UnwrapConvertToNullable(Expression expression)
+		static Expression UnwrapConvertToNullable(Expression expression)
         {
             var unary = expression as UnaryExpression;
             if (unary != null && expression.NodeType == ExpressionType.Convert && expression.Type.IsNullableType())
@@ -233,11 +233,11 @@ namespace DelegateDecompiler
             MemberExpression memberExpression;
             if (IsHasValue(hasValue, out memberExpression))
             {
-                expression = new GetValueOrDefaultRemover(memberExpression.Expression).Visit(getValueOrDefault);
+	            expression = new GetValueOrDefaultRemover(memberExpression.Expression).Visit(getValueOrDefault);
                 if (expression != getValueOrDefault)
                     return true;
             }
-
+            
             expression = null;
             return false;
         }
@@ -252,12 +252,12 @@ namespace DelegateDecompiler
                 if (expression == callExpression.Object)
                     return true;
             }
-
+            
             expression = null;
             return false;
         }
 
-        static bool IsHasValue(Expression expression, out MemberExpression property)
+	    static bool IsHasValue(Expression expression, out MemberExpression property)
         {
             property = expression as MemberExpression;
             return property != null && property.Member.Name == "HasValue" && property.Expression != null && property.Expression.Type.IsNullableType();
@@ -324,7 +324,7 @@ namespace DelegateDecompiler
 
         protected override Expression VisitUnary(UnaryExpression node)
         {
-            if (node.NodeType == ExpressionType.Not &&
+            if (node.NodeType == ExpressionType.Not && 
                 node.Operand is BinaryExpression binary &&
                 Invert(ref binary))
             {
@@ -350,40 +350,40 @@ namespace DelegateDecompiler
             switch (expression.NodeType)
             {
                 case ExpressionType.Equal:
-                    {
-                        expression = Expression.NotEqual(expression.Left, expression.Right);
-                        return true;
-                    }
+                {
+                    expression = Expression.NotEqual(expression.Left, expression.Right);
+                    return true;
+                }
                 case ExpressionType.NotEqual:
-                    {
-                        expression = Expression.Equal(expression.Left, expression.Right);
-                        return true;
-                    }
+                {
+                    expression = Expression.Equal(expression.Left, expression.Right);
+                    return true;
+                }
                 case ExpressionType.LessThan:
-                    {
-                        expression = Expression.GreaterThanOrEqual(expression.Left, expression.Right);
-                        return true;
-                    }
+                {
+                    expression = Expression.GreaterThanOrEqual(expression.Left, expression.Right);
+                    return true;
+                }
                 case ExpressionType.LessThanOrEqual:
-                    {
-                        expression = Expression.GreaterThan(expression.Left, expression.Right);
-                        return true;
-                    }
+                {
+                    expression = Expression.GreaterThan(expression.Left, expression.Right);
+                    return true;
+                }
                 case ExpressionType.GreaterThan:
-                    {
-                        expression = Expression.LessThanOrEqual(expression.Left, expression.Right);
-                        return true;
-                    }
+                {
+                    expression = Expression.LessThanOrEqual(expression.Left, expression.Right);
+                    return true;
+                }
                 case ExpressionType.GreaterThanOrEqual:
-                    {
-                        expression = Expression.LessThan(expression.Left, expression.Right);
-                        return true;
-                    }
+                {
+                    expression = Expression.LessThan(expression.Left, expression.Right);
+                    return true;
+                }
             }
             return false;
         }
 
-        class GetValueOrDefaultRemover : ExpressionVisitor
+        class GetValueOrDefaultRemover :ExpressionVisitor
         {
             readonly Expression expected;
 
@@ -417,19 +417,19 @@ namespace DelegateDecompiler
                 return node.Update(left, conversion, right);
             }
 
-            protected override Expression VisitUnary(UnaryExpression node)
-            {
-                var before = node;
-                var operand = Visit(node.Operand);
+	        protected override Expression VisitUnary(UnaryExpression node)
+	        {
+		        var before = node;
+		        var operand = Visit(node.Operand);
 
-                if (operand != before.Operand)
-                {
-                    operand = ConvertToNullable(operand);
-                }
+		        if (operand != before.Operand)
+		        {
+			        operand = ConvertToNullable(operand);
+		        }
 
-                return before.Update(operand);
-            }
-        }
+		        return before.Update(operand);
+	        }
+		}
 
         class GetValueOrDefaultToCoalesceConverter : ExpressionVisitor
         {
@@ -446,7 +446,7 @@ namespace DelegateDecompiler
                 return base.VisitMethodCall(node);
             }
         }
-
+        
         class LinqExpressionUnwrapper : ExpressionVisitor
         {
             public static Expression Unwrap(Expression expression)
@@ -459,7 +459,7 @@ namespace DelegateDecompiler
 
             protected override Expression VisitMethodCall(MethodCallExpression node)
             {
-                if (node.Method.Name == nameof(Expression.Constant) &&
+                if (node.Method.Name == nameof(Expression.Constant) && 
                     node.Method.DeclaringType == typeof(Expression) &&
                     node.Arguments[0] is ParameterExpression parameter)
                 {


### PR DESCRIPTION
@hazzik Alex,

PR #190 seems to solve nicely the changes I proposed in Processor.cs from #185

The implementation however raises a runtime issue when executing the query against a provider (unit test is /src/DelegateDecompiler.EntityFramework.Tests/TestGroup90AdditionalFeatures/Test01Issue152.cs).

The problem seems to be caused by the invocation of the compiled expression (OptimizeExpressionVisitor.cs#L455)
In the output Quoted lambda, ParameterExpressions instances in the body are not references to the Quoted Lambda corresponding Parameter.
