### PR TITLE
Refactoring local methods as Expression extentions

### DIFF
--- a/src/DelegateDecompiler.EntityFramework/AsyncDecompiledQueryProvider.cs
+++ b/src/DelegateDecompiler.EntityFramework/AsyncDecompiledQueryProvider.cs
@@ -43,7 +43,7 @@ namespace DelegateDecompiler.EntityFramework
 
         public override IQueryable<TElement> CreateQuery<TElement>(Expression expression)
         {
-            var decompiled = DecompileExpressionVisitor.Decompile(expression);
+            var decompiled = expression.Decompile();
             return new AsyncDecompiledQueryable<TElement>(this, inner.CreateQuery<TElement>(decompiled));
         }
 
@@ -54,7 +54,7 @@ namespace DelegateDecompiler.EntityFramework
             {
                 throw new InvalidOperationException("The source IQueryProvider doesn't implement IDbAsyncQueryProvider.");
             }
-            var decompiled = DecompileExpressionVisitor.Decompile(expression);
+            var decompiled = expression.Decompile();
             return asyncProvider.ExecuteAsync(decompiled, cancellationToken);
         }
 
@@ -65,7 +65,7 @@ namespace DelegateDecompiler.EntityFramework
             {
                 throw new InvalidOperationException("The source IQueryProvider doesn't implement IDbAsyncQueryProvider.");
             }
-            var decompiled = DecompileExpressionVisitor.Decompile(expression);
+            var decompiled = expression.Decompile();
             return asyncProvider.ExecuteAsync<TResult>(decompiled, cancellationToken);
         }
     }

--- a/src/DelegateDecompiler.EntityFrameworkCore/AsyncDecompiledQueryProvider.cs
+++ b/src/DelegateDecompiler.EntityFrameworkCore/AsyncDecompiledQueryProvider.cs
@@ -39,7 +39,7 @@ namespace DelegateDecompiler.EntityFrameworkCore
         // ReSharper disable once VirtualMemberNeverOverridden.Global
         public virtual TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
         {
-            var decompiled = DecompileExpressionVisitor.Decompile(expression);
+            var decompiled = expression.Decompile();
             return (TResult) MethodCache<TResult>.ExecuteAsync(AsyncQueryProvider, decompiled, cancellationToken);
         }
 
@@ -95,19 +95,19 @@ namespace DelegateDecompiler.EntityFrameworkCore
 
         public override IQueryable<TElement> CreateQuery<TElement>(Expression expression)
         {
-            var decompiled = DecompileExpressionVisitor.Decompile(expression);
+            var decompiled = expression.Decompile();
             return new EntityQueryable<TElement>(this, decompiled);
         }
 
         public virtual IAsyncEnumerable<TResult> ExecuteAsync<TResult>(Expression expression)
         {
-            var decompiled = DecompileExpressionVisitor.Decompile(expression);
+            var decompiled = expression.Decompile();
             return (IAsyncEnumerable<TResult>) MethodCache<TResult>.ExecuteAsync(AsyncQueryProvider, decompiled);
         }
 
         public new virtual Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
         {
-            var decompiled = DecompileExpressionVisitor.Decompile(expression);
+            var decompiled = expression.Decompile();
             return (Task<TResult>) MethodCache<TResult>.ExecuteAsync(AsyncQueryProvider, decompiled, cancellationToken);
         }
     }

--- a/src/DelegateDecompiler.EntityFrameworkCore5/AsyncDecompiledQueryProvider.cs
+++ b/src/DelegateDecompiler.EntityFrameworkCore5/AsyncDecompiledQueryProvider.cs
@@ -26,13 +26,13 @@ namespace DelegateDecompiler.EntityFrameworkCore
 
         public virtual TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
         {
-            var decompiled = DecompileExpressionVisitor.Decompile(expression);
+            var decompiled = expression.Decompile();
             return AsyncQueryProvider.ExecuteAsync<TResult>(decompiled, cancellationToken);
         }
 
         public override IQueryable<TElement> CreateQuery<TElement>(Expression expression)
         {
-            var decompiled = DecompileExpressionVisitor.Decompile(expression);
+            var decompiled = expression.Decompile();
             return new EntityQueryable<TElement>(this, decompiled);
         }
     }

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -7,11 +7,6 @@ namespace DelegateDecompiler
 {
     public class DecompileExpressionVisitor : ExpressionVisitor
     {
-        public static Expression Decompile(Expression expression)
-        {
-            return new DecompileExpressionVisitor().Visit(expression);
-        }
-
         protected override Expression VisitMember(MemberExpression node)
         {
             if (ShouldDecompile(node.Member) && node.Member is PropertyInfo property)

--- a/src/DelegateDecompiler/DecompileExpressionVisitor.cs
+++ b/src/DelegateDecompiler/DecompileExpressionVisitor.cs
@@ -7,6 +7,11 @@ namespace DelegateDecompiler
 {
     public class DecompileExpressionVisitor : ExpressionVisitor
     {
+        public static Expression Decompile(Expression expression)
+        {
+            return new DecompileExpressionVisitor().Visit(expression);
+        }
+
         protected override Expression VisitMember(MemberExpression node)
         {
             if (ShouldDecompile(node.Member) && node.Member is PropertyInfo property)

--- a/src/DelegateDecompiler/DecompiledQueryProvider.cs
+++ b/src/DelegateDecompiler/DecompiledQueryProvider.cs
@@ -40,19 +40,19 @@ namespace DelegateDecompiler
 
         public virtual IQueryable<TElement> CreateQuery<TElement>(Expression expression)
         {
-            var decompiled = DecompileExpressionVisitor.Decompile(expression);
+            var decompiled = expression.Decompile();
             return new DecompiledQueryable<TElement>(this, Inner.CreateQuery<TElement>(decompiled));
         }
 
         public object Execute(Expression expression)
         {
-            var decompiled = DecompileExpressionVisitor.Decompile(expression);
+            var decompiled = expression.Decompile();
             return Inner.Execute(decompiled);
         }
 
         public TResult Execute<TResult>(Expression expression)
         {
-            var decompiled = DecompileExpressionVisitor.Decompile(expression);
+            var decompiled = expression.Decompile();
             return Inner.Execute<TResult>(decompiled);
         }
     }

--- a/src/DelegateDecompiler/DefaultConfiguration.cs
+++ b/src/DelegateDecompiler/DefaultConfiguration.cs
@@ -9,9 +9,9 @@ namespace DelegateDecompiler
 
         public override bool ShouldDecompile(MemberInfo memberInfo)
         {
-            return memberInfo.GetCustomAttributes(typeof(DecompileAttribute), true).Length > 0 ||
-                   memberInfo.GetCustomAttributes(typeof(ComputedAttribute), true).Length > 0 ||
-                   computedMembers.Contains(memberInfo);
+            return computedMembers.Contains(memberInfo) ||
+                   memberInfo.GetCustomAttributes(typeof(DecompileAttribute), true).Length > 0 ||
+                   memberInfo.GetCustomAttributes(typeof(ComputedAttribute), true).Length > 0;
         }
 
         public override void RegisterDecompileableMember(MemberInfo property)

--- a/src/DelegateDecompiler/ExpressionExtensions.cs
+++ b/src/DelegateDecompiler/ExpressionExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace DelegateDecompiler
 {
@@ -10,7 +7,7 @@ namespace DelegateDecompiler
     {
         public static Expression Decompile(this Expression expression)
         {
-            return new DecompileExpressionVisitor().Visit(expression);
+            return DecompileExpressionVisitor.Decompile(expression);
         }
 
         public static Expression Optimize(this Expression expression)
@@ -18,9 +15,9 @@ namespace DelegateDecompiler
             return OptimizeExpressionVisitor.Optimize(expression);
         }
 
-        public static object Evaluate(this Expression expression)
+        public static T Evaluate<T>(this Expression expression)
         {
-            var func = Expression.Lambda<Func<object>>(expression).Compile();
+            var func = Expression.Lambda<Func<T>>(expression).Compile();
             return func.Invoke();
         }
     }

--- a/src/DelegateDecompiler/ExpressionExtensions.cs
+++ b/src/DelegateDecompiler/ExpressionExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace DelegateDecompiler
+{
+    public static class ExpressionExtensions
+    {
+        public static Expression Decompile(this Expression expression)
+        {
+            return new DecompileExpressionVisitor().Visit(expression);
+        }
+
+        public static Expression Optimize(this Expression expression)
+        {
+            return OptimizeExpressionVisitor.Optimize(expression);
+        }
+
+        public static object Evaluate(this Expression expression)
+        {
+            var func = Expression.Lambda<Func<object>>(expression).Compile();
+            return func.Invoke();
+        }
+    }
+}

--- a/src/DelegateDecompiler/ExpressionHelper.cs
+++ b/src/DelegateDecompiler/ExpressionHelper.cs
@@ -14,6 +14,5 @@ namespace DelegateDecompiler
         {
             return type.IsValueType ? Activator.CreateInstance(type) : null;
         }
-
     }
 }

--- a/src/DelegateDecompiler/ExpressionHelper.cs
+++ b/src/DelegateDecompiler/ExpressionHelper.cs
@@ -3,16 +3,17 @@ using System.Linq.Expressions;
 
 namespace DelegateDecompiler
 {
-    internal static class ExpressionHelper
+    public static class ExpressionHelper
     {
-        internal static Expression Default(Type type) =>
+        public static Expression Default(Type type) =>
             // LINQ to entities and possibly other providers don't support Expression.Default, so this gets the default
             // value and then uses an Expression.Constant instead
             Expression.Constant(GetDefaultValue(type), type);
 
-        internal static object GetDefaultValue(Type type)
+        public static object GetDefaultValue(Type type)
         {
             return type.IsValueType ? Activator.CreateInstance(type) : null;
         }
+
     }
 }

--- a/src/DelegateDecompiler/MethodBodyDecompiler.cs
+++ b/src/DelegateDecompiler/MethodBodyDecompiler.cs
@@ -28,7 +28,7 @@ namespace DelegateDecompiler
                 ? DecompileVirtual(methodType, method, args)
                 : DecompileConcrete(method, args);
 
-            var optimizedExpression = OptimizeExpressionVisitor.Optimize(expression);
+            var optimizedExpression = expression.Optimize();
 
             return Expression.Lambda(optimizedExpression, args.Select(x => (ParameterExpression) x.Expression));
         }

--- a/src/DelegateDecompiler/OptimizeExpressionVisitor.cs
+++ b/src/DelegateDecompiler/OptimizeExpressionVisitor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace DelegateDecompiler
@@ -51,7 +52,7 @@ namespace DelegateDecompiler
                 if (TryConvert1(test, ifTrueBinary, out result))
                     return result;
             }
-            
+
             var testBinary = test as BinaryExpression;
             var ifTrueConstant = ifTrue as ConstantExpression;
             var ifFalseConstant = ifFalse as ConstantExpression;
@@ -209,16 +210,16 @@ namespace DelegateDecompiler
 
         static Expression ConvertToNullable(Expression expression)
         {
-	        if (!expression.Type.IsValueType || expression.Type.IsNullableType()) return expression;
+            if (!expression.Type.IsValueType || expression.Type.IsNullableType()) return expression;
 
-	        var operand = expression.NodeType == ExpressionType.Convert
-		        ? ((UnaryExpression) expression).Operand
-		        : expression;
+            var operand = expression.NodeType == ExpressionType.Convert
+                ? ((UnaryExpression) expression).Operand
+                : expression;
 
-	        return Expression.Convert(operand, typeof(Nullable<>).MakeGenericType(expression.Type));
-		}
+            return Expression.Convert(operand, typeof(Nullable<>).MakeGenericType(expression.Type));
+        }
 
-		static Expression UnwrapConvertToNullable(Expression expression)
+        static Expression UnwrapConvertToNullable(Expression expression)
         {
             var unary = expression as UnaryExpression;
             if (unary != null && expression.NodeType == ExpressionType.Convert && expression.Type.IsNullableType())
@@ -233,11 +234,11 @@ namespace DelegateDecompiler
             MemberExpression memberExpression;
             if (IsHasValue(hasValue, out memberExpression))
             {
-	            expression = new GetValueOrDefaultRemover(memberExpression.Expression).Visit(getValueOrDefault);
+                expression = new GetValueOrDefaultRemover(memberExpression.Expression).Visit(getValueOrDefault);
                 if (expression != getValueOrDefault)
                     return true;
             }
-            
+
             expression = null;
             return false;
         }
@@ -252,12 +253,12 @@ namespace DelegateDecompiler
                 if (expression == callExpression.Object)
                     return true;
             }
-            
+
             expression = null;
             return false;
         }
 
-	    static bool IsHasValue(Expression expression, out MemberExpression property)
+        static bool IsHasValue(Expression expression, out MemberExpression property)
         {
             property = expression as MemberExpression;
             return property != null && property.Member.Name == "HasValue" && property.Expression != null && property.Expression.Type.IsNullableType();
@@ -324,7 +325,7 @@ namespace DelegateDecompiler
 
         protected override Expression VisitUnary(UnaryExpression node)
         {
-            if (node.NodeType == ExpressionType.Not && 
+            if (node.NodeType == ExpressionType.Not &&
                 node.Operand is BinaryExpression binary &&
                 Invert(ref binary))
             {
@@ -351,35 +352,35 @@ namespace DelegateDecompiler
             switch (expression.NodeType)
             {
                 case ExpressionType.Equal:
-                {
-                    expression = Expression.NotEqual(expression.Left, expression.Right);
-                    return true;
-                }
+                    {
+                        expression = Expression.NotEqual(expression.Left, expression.Right);
+                        return true;
+                    }
                 case ExpressionType.NotEqual:
-                {
-                    expression = Expression.Equal(expression.Left, expression.Right);
-                    return true;
-                }
+                    {
+                        expression = Expression.Equal(expression.Left, expression.Right);
+                        return true;
+                    }
                 case ExpressionType.LessThan:
-                {
-                    expression = Expression.GreaterThanOrEqual(expression.Left, expression.Right);
-                    return true;
-                }
+                    {
+                        expression = Expression.GreaterThanOrEqual(expression.Left, expression.Right);
+                        return true;
+                    }
                 case ExpressionType.LessThanOrEqual:
-                {
-                    expression = Expression.GreaterThan(expression.Left, expression.Right);
-                    return true;
-                }
+                    {
+                        expression = Expression.GreaterThan(expression.Left, expression.Right);
+                        return true;
+                    }
                 case ExpressionType.GreaterThan:
-                {
-                    expression = Expression.LessThanOrEqual(expression.Left, expression.Right);
-                    return true;
-                }
+                    {
+                        expression = Expression.LessThanOrEqual(expression.Left, expression.Right);
+                        return true;
+                    }
                 case ExpressionType.GreaterThanOrEqual:
-                {
-                    expression = Expression.LessThan(expression.Left, expression.Right);
-                    return true;
-                }
+                    {
+                        expression = Expression.LessThan(expression.Left, expression.Right);
+                        return true;
+                    }
             }
             return false;
         }
@@ -418,19 +419,19 @@ namespace DelegateDecompiler
                 return node.Update(left, conversion, right);
             }
 
-	        protected override Expression VisitUnary(UnaryExpression node)
-	        {
-		        var before = node;
-		        var operand = Visit(node.Operand);
+            protected override Expression VisitUnary(UnaryExpression node)
+            {
+                var before = node;
+                var operand = Visit(node.Operand);
 
-		        if (operand != before.Operand)
-		        {
-			        operand = ConvertToNullable(operand);
-		        }
+                if (operand != before.Operand)
+                {
+                    operand = ConvertToNullable(operand);
+                }
 
-		        return before.Update(operand);
-	        }
-		}
+                return before.Update(operand);
+            }
+        }
 
         class GetValueOrDefaultToCoalesceConverter : ExpressionVisitor
         {
@@ -447,7 +448,7 @@ namespace DelegateDecompiler
                 return base.VisitMethodCall(node);
             }
         }
-        
+
         class LinqExpressionUnwrapper : ExpressionVisitor
         {
             readonly Dictionary<Expression, Expression> replacements = new Dictionary<Expression, Expression>();
@@ -455,7 +456,7 @@ namespace DelegateDecompiler
             public static Expression Unwrap(Expression expression)
             {
                 var visit = new LinqExpressionUnwrapper().Visit(expression);
-                var func = EvaluateExpression(visit);
+                var func = visit.Evaluate() as Expression;
                 return Expression.Quote(func);
             }
 
@@ -473,7 +474,7 @@ namespace DelegateDecompiler
                 {
                     if (!replacements.TryGetValue(node, out var parameter))
                     {
-                        parameter = Expression.Constant(EvaluateExpression(node));
+                        parameter = Expression.Constant(node.Evaluate());
                         replacements[node] = parameter;
                     }
 
@@ -481,12 +482,6 @@ namespace DelegateDecompiler
                 }
 
                 return base.VisitMethodCall(node);
-            }
-
-            static Expression EvaluateExpression(Expression visit)
-            {
-                var func = Expression.Lambda<Func<Expression>>(visit).Compile();
-                return func.Invoke();
             }
         }
 

--- a/src/DelegateDecompiler/OptimizeExpressionVisitor.cs
+++ b/src/DelegateDecompiler/OptimizeExpressionVisitor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Linq.Expressions;
 
 namespace DelegateDecompiler

--- a/src/DelegateDecompiler/OptimizeExpressionVisitor.cs
+++ b/src/DelegateDecompiler/OptimizeExpressionVisitor.cs
@@ -456,7 +456,7 @@ namespace DelegateDecompiler
             public static Expression Unwrap(Expression expression)
             {
                 var visit = new LinqExpressionUnwrapper().Visit(expression);
-                var func = visit.Evaluate() as Expression;
+                var func = visit.Evaluate<Expression>();
                 return Expression.Quote(func);
             }
 
@@ -474,7 +474,7 @@ namespace DelegateDecompiler
                 {
                     if (!replacements.TryGetValue(node, out var parameter))
                     {
-                        parameter = Expression.Constant(node.Evaluate());
+                        parameter = Expression.Constant(node.Evaluate<Expression>());
                         replacements[node] = parameter;
                     }
 


### PR DESCRIPTION
Refactoring local methods Decompile/Optimize/EvaluateExpression into extension methods for `System.Linq.Expressions.Expression`