### PR TITLE
Feat - Queryable reference handling

### DIFF
--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.31.1.0 on Monday, 17 October 2022 17:28
+## Documentation produced for DelegateDecompiler, version 0.32.0.0 on Monday, 17 October 2022 16:21
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).
@@ -147,7 +147,10 @@ More will appear as we move forward.*
 ### Group: Additional Features
 #### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
 - Supported
-  * Subquery As Context Extension Method (line 68)
+  * Subquery As Context Extension Method (line 69)
+  * Filter With Subquery Reference (line 112)
+- **Not Supported**
+  * Subquery As Variable Reference (line 82)
 
 
 

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.31.1.0 on Monday, 17 October 2022 17:28
+## Documentation produced for DelegateDecompiler, version 0.32.0.0 on Monday, 17 October 2022 16:21
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).
@@ -849,7 +849,7 @@ SELECT
 ### Group: Additional Features
 #### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
 - Supported
-  * Subquery As Context Extension Method (line 68)
+  * Subquery As Context Extension Method (line 69)
      * T-Sql executed is
 
 ```SQL
@@ -874,6 +874,32 @@ SELECT
     )  AS [Project4]
 ```
 
+  * Filter With Subquery Reference (line 112)
+     * T-Sql executed is
+
+```SQL
+SELECT 
+    CASE WHEN ( EXISTS (SELECT 
+        1 AS [C1]
+        FROM [dbo].[EfParents] AS [Extent1]
+        WHERE  EXISTS (SELECT 
+            1 AS [C1]
+            FROM ( SELECT 
+                [Extent2].[EfParentId] AS [EfParentId], 
+                (SELECT 
+                    COUNT(1) AS [A1]
+                    FROM [dbo].[EfChilds] AS [Extent3]
+                    WHERE [Extent2].[EfParentId] = [Extent3].[EfParentId]) AS [C1]
+                FROM [dbo].[EfParents] AS [Extent2]
+            )  AS [Project1]
+            WHERE (0 = [Project1].[C1]) AND ([Project1].[EfParentId] = [Extent1].[EfParentId])
+        )
+    )) THEN cast(1 as bit) ELSE cast(0 as bit) END AS [C1]
+    FROM  ( SELECT 1 AS X ) AS [SingleRowTable1]
+```
+
+- **Not Supported**
+  * Subquery As Variable Reference (line 82)
 
 
 

--- a/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFramework.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.31.1.0 on Monday, 17 October 2022 17:28
+## Documentation produced for DelegateDecompiler, version 0.32.0.0 on Monday, 17 October 2022 16:21
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework v6.1](http://msdn.microsoft.com/en-us/data/aa937723) (EF).
@@ -55,8 +55,8 @@ More will appear as we move forward.*
   * [DateTime](../TestGroup50Types/Test05DateTime.cs) (1 tests)
 
 ### Group: Additional Features
-- Supported
-  * [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs) (1 tests)
+- **Partially Supported**
+  * [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs) (2 of 3 tests passed)
 
 
 The End

--- a/src/DelegateDecompiler.EntityFramework/AsyncDecompiledQueryProvider.cs
+++ b/src/DelegateDecompiler.EntityFramework/AsyncDecompiledQueryProvider.cs
@@ -43,7 +43,7 @@ namespace DelegateDecompiler.EntityFramework
 
         public override IQueryable<TElement> CreateQuery<TElement>(Expression expression)
         {
-            var decompiled = expression.Decompile();
+            var decompiled = expression.Decompile().Dereference();
             return new AsyncDecompiledQueryable<TElement>(this, inner.CreateQuery<TElement>(decompiled));
         }
 
@@ -54,7 +54,7 @@ namespace DelegateDecompiler.EntityFramework
             {
                 throw new InvalidOperationException("The source IQueryProvider doesn't implement IDbAsyncQueryProvider.");
             }
-            var decompiled = expression.Decompile();
+            var decompiled = expression.Decompile().Dereference();
             return asyncProvider.ExecuteAsync(decompiled, cancellationToken);
         }
 
@@ -65,7 +65,7 @@ namespace DelegateDecompiler.EntityFramework
             {
                 throw new InvalidOperationException("The source IQueryProvider doesn't implement IDbAsyncQueryProvider.");
             }
-            var decompiled = expression.Decompile();
+            var decompiled = expression.Decompile().Dereference();
             return asyncProvider.ExecuteAsync<TResult>(decompiled, cancellationToken);
         }
     }

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.31.1.0 on Monday, 17 October 2022 17:28
+## Documentation produced for DelegateDecompiler, version 0.32.0.0 on Monday, 17 October 2022 16:21
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.31.1.0 on Monday, 17 October 2022 17:28
+## Documentation produced for DelegateDecompiler, version 0.32.0.0 on Monday, 17 October 2022 16:21
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).

--- a/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.31.1.0 on Monday, 17 October 2022 17:28
+## Documentation produced for DelegateDecompiler, version 0.32.0.0 on Monday, 17 October 2022 16:21
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).

--- a/src/DelegateDecompiler.EntityFrameworkCore/AsyncDecompiledQueryProvider.cs
+++ b/src/DelegateDecompiler.EntityFrameworkCore/AsyncDecompiledQueryProvider.cs
@@ -39,7 +39,7 @@ namespace DelegateDecompiler.EntityFrameworkCore
         // ReSharper disable once VirtualMemberNeverOverridden.Global
         public virtual TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
         {
-            var decompiled = expression.Decompile();
+            var decompiled = expression.Decompile().Dereference();
             return (TResult)MethodCache<TResult>.ExecuteAsync(AsyncQueryProvider, decompiled, cancellationToken);
         }
 
@@ -95,19 +95,19 @@ namespace DelegateDecompiler.EntityFrameworkCore
 
         public override IQueryable<TElement> CreateQuery<TElement>(Expression expression)
         {
-            var decompiled = expression.Decompile();
+            var decompiled = expression.Decompile().Dereference();
             return new EntityQueryable<TElement>(this, decompiled);
         }
 
         public virtual IAsyncEnumerable<TResult> ExecuteAsync<TResult>(Expression expression)
         {
-            var decompiled = expression.Decompile();
+            var decompiled = expression.Decompile().Dereference();
             return (IAsyncEnumerable<TResult>)MethodCache<TResult>.ExecuteAsync(AsyncQueryProvider, decompiled);
         }
 
         public new virtual Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
         {
-            var decompiled = expression.Decompile();
+            var decompiled = expression.Decompile().Dereference();
             return (Task<TResult>)MethodCache<TResult>.ExecuteAsync(AsyncQueryProvider, decompiled, cancellationToken);
         }
     }

--- a/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.31.1.0 on Monday, 17 October 2022 17:27
+## Documentation produced for DelegateDecompiler, version 0.32.0.0 on Monday, 17 October 2022 16:21
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -146,7 +146,10 @@ More will appear as we move forward.*
 ### Group: Additional Features
 #### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
 - Supported
-  * Subquery As Context Extension Method (line 68)
+  * Subquery As Context Extension Method (line 69)
+  * Filter With Subquery Reference (line 112)
+- **Not Supported**
+  * Subquery As Variable Reference (line 82)
 
 
 

--- a/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.31.1.0 on Monday, 17 October 2022 17:27
+## Documentation produced for DelegateDecompiler, version 0.32.0.0 on Monday, 17 October 2022 16:21
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -506,13 +506,22 @@ More will appear as we move forward.*
 ### Group: Additional Features
 #### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
 - Supported
-  * Subquery As Context Extension Method (line 68)
+  * Subquery As Context Extension Method (line 69)
      * T-Sql executed is
 
 ```SQL
 
 ```
 
+  * Filter With Subquery Reference (line 112)
+     * T-Sql executed is
+
+```SQL
+
+```
+
+- **Not Supported**
+  * Subquery As Variable Reference (line 82)
 
 
 

--- a/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore3.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.31.1.0 on Monday, 17 October 2022 17:27
+## Documentation produced for DelegateDecompiler, version 0.32.0.0 on Monday, 17 October 2022 16:21
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -55,8 +55,8 @@ More will appear as we move forward.*
   * [DateTime](../TestGroup50Types/Test05DateTime.cs) (1 tests)
 
 ### Group: Additional Features
-- Supported
-  * [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs) (1 tests)
+- **Partially Supported**
+  * [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs) (2 of 3 tests passed)
 
 
 The End

--- a/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/DetailedListOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Detail of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.31.1.0 on Monday, 17 October 2022 17:28
+## Documentation produced for DelegateDecompiler, version 0.32.0.0 on Monday, 17 October 2022 16:21
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -146,7 +146,10 @@ More will appear as we move forward.*
 ### Group: Additional Features
 #### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
 - Supported
-  * Subquery As Context Extension Method (line 68)
+  * Subquery As Context Extension Method (line 69)
+  * Filter With Subquery Reference (line 112)
+- **Not Supported**
+  * Subquery As Variable Reference (line 82)
 
 
 

--- a/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/DetailedListOfSupportedCommandsWithSQL.md
@@ -1,6 +1,6 @@
 Detail With Sql of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.31.1.0 on Monday, 17 October 2022 17:28
+## Documentation produced for DelegateDecompiler, version 0.32.0.0 on Monday, 17 October 2022 16:21
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -775,7 +775,7 @@ WHERE [e].[StartDate] > '2000-01-01T00:00:00.0000000'
 ### Group: Additional Features
 #### [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs):
 - Supported
-  * Subquery As Context Extension Method (line 68)
+  * Subquery As Context Extension Method (line 69)
      * T-Sql executed is
 
 ```SQL
@@ -786,6 +786,27 @@ SELECT [e0].[EfParentId] AS [ParentId], COALESCE((
 FROM [EfParents] AS [e0]
 ```
 
+  * Filter With Subquery Reference (line 112)
+     * T-Sql executed is
+
+```SQL
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [EfParents] AS [e]
+        WHERE EXISTS (
+            SELECT 1
+            FROM [EfParents] AS [e0]
+            WHERE ((
+                SELECT COUNT(*)
+                FROM [EfChildren] AS [e1]
+                WHERE [e0].[EfParentId] = [e1].[EfParentId]) = 0) AND ([e0].[EfParentId] = [e].[EfParentId]))) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+```
+
+- **Not Supported**
+  * Subquery As Variable Reference (line 82)
 
 
 

--- a/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
+++ b/src/DelegateDecompiler.EntityFrameworkCore5.Tests/GeneratedDocumentation/SummaryOfSupportedCommands.md
@@ -1,6 +1,6 @@
 Summary of supported commands
 ============
-## Documentation produced for DelegateDecompiler, version 0.31.1.0 on Monday, 17 October 2022 17:28
+## Documentation produced for DelegateDecompiler, version 0.32.0.0 on Monday, 17 October 2022 16:21
 
 This file documents what linq commands **DelegateDecompiler** supports when
 working with [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/) (EF).
@@ -55,8 +55,8 @@ More will appear as we move forward.*
   * [DateTime](../TestGroup50Types/Test05DateTime.cs) (1 tests)
 
 ### Group: Additional Features
-- Supported
-  * [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs) (1 tests)
+- **Partially Supported**
+  * [Nested Expressions](../TestGroup90AdditionalFeatures/Test01NestedExpressions.cs) (2 of 3 tests passed)
 
 
 The End

--- a/src/DelegateDecompiler.EntityFrameworkCore5/AsyncDecompiledQueryProvider.cs
+++ b/src/DelegateDecompiler.EntityFrameworkCore5/AsyncDecompiledQueryProvider.cs
@@ -27,14 +27,14 @@ namespace DelegateDecompiler.EntityFrameworkCore
 
         public virtual TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
         {
-            var decompiled = expression.Decompile();
+            var decompiled = expression.Decompile().Dereference();
             return AsyncQueryProvider.ExecuteAsync<TResult>(decompiled, cancellationToken);
         }
 
         [SuppressMessage("EntityFramework", "EF1001")]
         public override IQueryable<TElement> CreateQuery<TElement>(Expression expression)
         {
-            var decompiled = expression.Decompile();
+            var decompiled = expression.Decompile().Dereference();
             return new EntityQueryable<TElement>(this, decompiled);
         }
     }

--- a/src/DelegateDecompiler.Tests/NestedExpressionsTests.cs
+++ b/src/DelegateDecompiler.Tests/NestedExpressionsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using NUnit.Framework;
 
 namespace DelegateDecompiler.Tests
@@ -13,6 +14,21 @@ namespace DelegateDecompiler.Tests
         static int p2 => 0;
         int M1() => 0;
         static int M2() => 0;
+
+        readonly IQueryable<int> fQref1 = Enumerable.Empty<int>().AsQueryable();
+        static IQueryable<int> fQref2 = Enumerable.Empty<int>().AsQueryable();
+        [Decompile]
+        IQueryable<int> pQref1 => Enumerable.Empty<int>().AsQueryable();
+        [Decompile]
+        static IQueryable<int> pQref2 => Enumerable.Empty<int>().AsQueryable();
+        [Decompile]
+        IQueryable<int> MQref1() => Enumerable.Empty<int>().AsQueryable();
+        [Decompile]
+        static IQueryable<int> MQref2() => Enumerable.Empty<int>().AsQueryable();
+        [Decompile]
+        IQueryable<int> ParamedMQref1(int floor) => Enumerable.Empty<int>().AsQueryable().Where(x => x >= floor);
+        [Decompile]
+        static IQueryable<int> ParamedMQref2(int floor) => Enumerable.Empty<int>().AsQueryable().Where(x => x >= floor);
 
         [Test]
         public void TestNestedExpression()
@@ -176,6 +192,111 @@ namespace DelegateDecompiler.Tests
             Test<Func<IEnumerable<int>, int>>(
                 ints => ints.SingleOrDefault(i => i == M2()),
                 ints => ints.SingleOrDefault(i => i == M2())
+            );
+        }
+
+        [Test]
+        //[Test, Ignore("Difference is expected")]
+        public void TestQueryableBoundAsVariable()
+        {
+            IQueryable<int> query = Enumerable.Empty<int>().AsQueryable().Where(i => i >= 0);
+            Test<Func<IQueryable<int>, IQueryable<int>>>(
+                ints => Enumerable.Empty<int>().AsQueryable().Where(i => i >= 0),
+                ints => query
+            );
+        }
+
+        [Test]
+        //[Test, Ignore("Difference is expected")]
+        public void TestQueryableRefFromField()
+        {
+            Test<Func<IQueryable<int>, IQueryable<int>>>(
+                ints => Enumerable.Empty<int>().AsQueryable().Where(i => i >= 0),
+                ints => fQref1.Where(i => i >= 0)
+            );
+        }
+
+        [Test]
+        //[Test, Ignore("Difference is expected")]
+        public void TestQueryableRefFromStaticField()
+        {
+            Test<Func<IQueryable<int>, IQueryable<int>>>(
+                ints => Enumerable.Empty<int>().AsQueryable().Where(i => i >= 0),
+                ints => fQref2.Where(i => i >= 0)
+            );
+        }
+
+        [Test]
+        public void TestQueryableRefFromProperty()
+        {
+            Test<Func<IQueryable<int>, IQueryable<int>>>(
+                ints => Enumerable.Empty<int>().AsQueryable().Where(i => i >= 0),
+                ints => pQref1.Where(i => i >= 0)
+            );
+        }
+
+        [Test]
+        public void TestQueryableRefFromStaticProperty()
+        {
+            Test<Func<IQueryable<int>, IQueryable<int>>>(
+                ints => Enumerable.Empty<int>().AsQueryable().Where(i => i >= 0),
+                ints => pQref2.Where(i => i >= 0)
+            );
+        }
+
+        [Test]
+        public void TestQueryableRefFromMethod()
+        {
+            Test<Func<IQueryable<int>, IQueryable<int>>>(
+                ints => Enumerable.Empty<int>().AsQueryable().Where(i => i >= 0),
+                ints => MQref1().Where(i => i >= 0)
+            );
+        }
+
+        [Test]
+        public void TestQueryableRefFromStaticMethod()
+        {
+            Test<Func<IQueryable<int>, IQueryable<int>>>(
+                ints => Enumerable.Empty<int>().AsQueryable().Where(i => i >= 0),
+                ints => MQref2().Where(i => i >= 0)
+            );
+        }
+
+        [Test]
+        public void TestQueryableRefFromMethodWithBoundParameters()
+        {
+            var floor = 10;
+            Test<Func<IQueryable<int>, IQueryable<int>>>(
+                ints => Enumerable.Empty<int>().AsQueryable().Where(x => x >= floor).Where(i => i >= 0),
+                ints => ParamedMQref1(floor).Where(i => i >= 0)
+            );
+        }
+
+        [Test]
+        public void TestQueryableRefFromStaticMethoWithBoundParameters()
+        {
+            var floor = 10;
+            Test<Func<IQueryable<int>, IQueryable<int>>>(
+                ints => Enumerable.Empty<int>().AsQueryable().Where(x => x >= floor).Where(i => i >= 0),
+                ints => ParamedMQref1(floor).Where(i => i >= 0)
+            );
+        }
+
+        [Test]
+        public void TestQueryableRefFromMethodWithUnboundParameters()
+        {
+            Test<Func<IQueryable<int>, int, IQueryable<int>>>(
+                (ints, floor) => Enumerable.Empty<int>().AsQueryable().Where(x => x >= floor).Where(i => i >= 0),
+                (ints, floor) => ParamedMQref1(floor).Where(i => i >= 0)
+            );
+        }
+
+        [Test]
+        public void TestQueryableRefFromStaticMethoWithUnboundParameters()
+        {
+            Test<Func<IQueryable<int>, int, IQueryable<int>>>(
+                (ints, floor) => Enumerable.Empty<int>().AsQueryable().Where(x => x >= floor).Where(i => i >= 0),
+                (ints, floor) => ParamedMQref1(floor).Where(i => i >= 0)
             );
         }
     }

--- a/src/DelegateDecompiler.Tests/NestedExpressionsTests.cs
+++ b/src/DelegateDecompiler.Tests/NestedExpressionsTests.cs
@@ -195,8 +195,7 @@ namespace DelegateDecompiler.Tests
             );
         }
 
-        [Test]
-        //[Test, Ignore("Difference is expected")]
+        [Test, Ignore("Difference is expected")]
         public void TestQueryableBoundAsVariable()
         {
             IQueryable<int> query = Enumerable.Empty<int>().AsQueryable().Where(i => i >= 0);
@@ -206,8 +205,7 @@ namespace DelegateDecompiler.Tests
             );
         }
 
-        [Test]
-        //[Test, Ignore("Difference is expected")]
+        [Test, Ignore("Difference is expected")]
         public void TestQueryableRefFromField()
         {
             Test<Func<IQueryable<int>, IQueryable<int>>>(
@@ -216,8 +214,7 @@ namespace DelegateDecompiler.Tests
             );
         }
 
-        [Test]
-        //[Test, Ignore("Difference is expected")]
+        [Test, Ignore("Difference is expected")]
         public void TestQueryableRefFromStaticField()
         {
             Test<Func<IQueryable<int>, IQueryable<int>>>(

--- a/src/DelegateDecompiler/DecompileExtensions.cs
+++ b/src/DelegateDecompiler/DecompileExtensions.cs
@@ -24,7 +24,7 @@ namespace DelegateDecompiler
             {
                 {expression.Parameters[0], Expression.Constant(@delegate.Target)}
             });
-            var transformed = visitor.Visit(expression.Body);
+            var transformed = visitor.Visit(expression.Body).Dereference();
             return Expression.Lambda(transformed, expression.Parameters.Skip(1));
         }
 

--- a/src/DelegateDecompiler/DecompiledQueryProvider.cs
+++ b/src/DelegateDecompiler/DecompiledQueryProvider.cs
@@ -40,19 +40,19 @@ namespace DelegateDecompiler
 
         public virtual IQueryable<TElement> CreateQuery<TElement>(Expression expression)
         {
-            var decompiled = expression.Decompile();
+            var decompiled = expression.Decompile().Dereference();
             return new DecompiledQueryable<TElement>(this, Inner.CreateQuery<TElement>(decompiled));
         }
 
         public object Execute(Expression expression)
         {
-            var decompiled = expression.Decompile();
+            var decompiled = expression.Decompile().Dereference();
             return Inner.Execute(decompiled);
         }
 
         public TResult Execute<TResult>(Expression expression)
         {
-            var decompiled = expression.Decompile();
+            var decompiled = expression.Decompile().Dereference();
             return Inner.Execute<TResult>(decompiled);
         }
     }

--- a/src/DelegateDecompiler/ExpressionExtensions.cs
+++ b/src/DelegateDecompiler/ExpressionExtensions.cs
@@ -10,6 +10,11 @@ namespace DelegateDecompiler
             return DecompileExpressionVisitor.Decompile(expression);
         }
 
+        public static Expression Dereference(this Expression expression)
+        {
+            return ReferencedQueryableExpressionVisitor.Decompile(expression);
+        }
+
         public static Expression Optimize(this Expression expression)
         {
             return OptimizeExpressionVisitor.Optimize(expression);

--- a/src/DelegateDecompiler/ReferencedQueryableDecompilerVisitor.cs
+++ b/src/DelegateDecompiler/ReferencedQueryableDecompilerVisitor.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace DelegateDecompiler
+{
+    public class ReferencedQueryableExpressionVisitor
+        : ExpressionVisitor
+    {
+        public static Expression Decompile(Expression expression)
+        {
+            return new ReferencedQueryableExpressionVisitor().Visit(expression);
+        }
+
+        public override Expression Visit(Expression node)
+        {
+            var result = base.Visit(node);
+            return result;
+        }
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            if (typeof(IQueryable).IsAssignableFrom(node.Type))
+            {
+                if (Configuration.Instance.ShouldDecompile(node.Member))
+                {
+                    return node.Decompile().Dereference();
+                }
+                else if (node.Member is FieldInfo)
+                {
+                    return (node.Evaluate<IQueryable>()).Expression.Decompile();
+                }
+            }
+            return base.VisitMember(node);
+        }
+
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            if (typeof(IQueryable).IsAssignableFrom(node.Type))
+            {
+                if (Configuration.Instance.ShouldDecompile(node.Method))
+                {
+                    return node.Decompile().Dereference();
+                }
+            }
+            return base.VisitMethodCall(node);
+        }
+    }
+}


### PR DESCRIPTION
@hazzik Alex,

Working on subsequent tests upon #152 and its fixes, I tried more ways to handle sub/referenced queries than just the DbContext extension method issue.

The tests are provided within the first commit of this PR (you can fork this to see how and why they fail).



