### PR TITLE
Fix null reference error in TypeHierarchy.cs

### DIFF
--- a/src/DelegateDecompiler/TypeHierarchy.cs
+++ b/src/DelegateDecompiler/TypeHierarchy.cs
@@ -47,6 +47,11 @@ namespace DelegateDecompiler
 
         static IEnumerable<Type> BuildChildren(Type type, ILookup<Type, Type> children)
         {
+            if (type == null)
+            {
+                return Enumerable.Empty<Type>();
+            }
+
             if (!type.IsGenericType)
             {
                 return children[type];


### PR DESCRIPTION
This fixes hazzik/DelegateDecompiler/issues/218,  a null reference error that can occur if the root type is not eliminated from the list of descendants generated in MethodBodyDecompiler.DecompileVirtual.  For some reason, in my application, something within the reflection process used in DecompileVirtual generated two different references to the same root interface where the method signature was declared.  This meant that a type with a null BaseType property was included in the list of descendants, eventually yielding the null reference error in BuildChildren.  I tested the modification locally and it works well, but it'd be great to have it fixed in the main branch so I can continue to get all the updates and features provided by this genius library!

