### PR TITLE
Do not consider final method overridable

### DIFF
--- a/src/DelegateDecompiler/MethodBodyDecompiler.cs
+++ b/src/DelegateDecompiler/MethodBodyDecompiler.cs
@@ -24,8 +24,11 @@ namespace DelegateDecompiler
             if (!method.IsStatic)
                 args.Insert(0, Expression.Parameter(methodType, "this"));
 
-            var expression = method.IsVirtual
-                ? DecompileVirtual(methodType, method, args)
+            // If a method is final, it is not overridable:
+            // https://learn.microsoft.com/en-us/dotnet/api/system.reflection.methodbase.isvirtual?view=netframework-4.7.2#remarks
+            var methodIsOverridable = method.IsVirtual && !method.IsFinal;
+            var expression = methodIsOverridable
+                ? DecompileOverridable(methodType, method, args)
                 : DecompileConcrete(method, args);
 
             var optimizedExpression = expression.Optimize();
@@ -63,7 +66,7 @@ namespace DelegateDecompiler
             return result;
         }
 
-        static Expression DecompileVirtual(Type declaringType, MethodInfo method, IList<Address> args)
+        static Expression DecompileOverridable(Type declaringType, MethodInfo method, IList<Address> args)
         {
             if (declaringType == null)
                 throw new InvalidOperationException($"Method {method.Name} does not have a declaring type");

--- a/src/DelegateDecompiler/MethodBodyDecompiler.cs
+++ b/src/DelegateDecompiler/MethodBodyDecompiler.cs
@@ -24,10 +24,7 @@ namespace DelegateDecompiler
             if (!method.IsStatic)
                 args.Insert(0, Expression.Parameter(methodType, "this"));
 
-            // If a method is final, it is not overridable:
-            // https://learn.microsoft.com/en-us/dotnet/api/system.reflection.methodbase.isvirtual?view=netframework-4.7.2#remarks
-            var methodIsOverridable = method.IsVirtual && !method.IsFinal;
-            var expression = methodIsOverridable
+            var expression = method.IsVirtual && !method.IsFinal
                 ? DecompileOverridable(methodType, method, args)
                 : DecompileConcrete(method, args);
 


### PR DESCRIPTION
As noted [here](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.methodbase.isvirtual?view=netframework-4.7.2#remarks), _"To determine if a method is overridable, it is not sufficient to check that IsVirtual is true. For a method to be overridable, IsVirtual must be true and [IsFinal](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.methodbase.isfinal?view=netframework-4.7.2) must be false."_

I may be wrong, but I think this PR may increase performance and keep functionnality intact.

(By the way, I submitted another PR by mistake earlier, trying to update my fork, and it seems to have linked a bunch of stuff to it, sorry)

I did a small benchmark:

```csharp
BenchmarkRunner.Run<Benchmark>();
return;

public interface I
{
    string? P { get; set; }
}

public class C : I
{
    public string? P { get; set; }
}

public class Benchmark
{
    static readonly Type Type = typeof(C);
    
    static readonly MethodInfo MethodInfo = Type.GetProperty(nameof(C.P))?.GetMethod
        ?? throw new ArgumentException("Did not find method");

    [Benchmark]
    public void DecompileNew()
    {
        MethodBodyDecompiler.Decompile(MethodInfo, Type);
    }
    
    [Benchmark]
    public void DecompileOld()
    {
        MethodBodyDecompiler.DecompileOld(MethodInfo, Type);
    }
}
```

```
| Method       | Mean         | Error      | StdDev      |
|------------- |-------------:|-----------:|------------:|
| DecompileNew |     3.030 us |  0.0871 us |   0.2554 us |
| DecompileOld | 2,292.221 us | 60.4400 us | 175.3475 us |
```