### PR TITLE
Fix slow optimization of nested binary expressions

### DIFF
--- a/src/DelegateDecompiler.Tests/Issue220And243.cs
+++ b/src/DelegateDecompiler.Tests/Issue220And243.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using NUnit.Framework;
+
+namespace DelegateDecompiler.Tests
+{
+    [TestFixture]
+    public class Issue220And243
+    {
+        [Test]
+        public void ShouldOptimizeSimpleExpressionQuickly()
+        {
+            // Somewhat artificial example, as Contains could be used instead. But the problem exists for every combination of binary operators.
+            Expression<Func<Employee, bool>> expr = e => e.Id == 1 || e.Id == 2 || e.Id == 3 || e.Id == 4 || e.Id == 5 || e.Id == 6 || e.Id == 7 || e.Id == 8
+                || e.Id == 9 || e.Id == 10 || e.Id == 11 || e.Id == 12 || e.Id == 13 || e.Id == 14 || e.Id == 15 || e.Id == 16 || e.Id == 17 || e.Id == 18
+                || e.Id == 19 || e.Id == 20 || e.Id == 21 || e.Id == 22 || e.Id == 23 || e.Id == 24 || e.Id == 25 || e.Id == 26 || e.Id == 27;
+
+            var sw = Stopwatch.StartNew();
+            OptimizeExpressionVisitor.Optimize(expr);
+
+            // Not so good to test runtime performance, but it's a working indicator. On my machine without fix > 20 s, with fix < 10 ms.
+            Assert.That(sw.ElapsedMilliseconds, Is.LessThan(1000));
+        }
+    }
+}

--- a/src/DelegateDecompiler/OptimizeExpressionVisitor.cs
+++ b/src/DelegateDecompiler/OptimizeExpressionVisitor.cs
@@ -330,7 +330,7 @@ namespace DelegateDecompiler
                 }
             }
 
-            return base.VisitBinary(node);
+            return node.Update(left, VisitAndConvert(node.Conversion, nameof (VisitBinary)), right);
         }
 
         protected override Expression VisitUnary(UnaryExpression node)


### PR DESCRIPTION
Fixes #220 and #243.

For nested binary expressions (e.g. && or || after each other) the `OptimizeExpressionVisitor` has a time complexity of O(2^n). This is due to the implementation of `OptimizeExpressionVisitor.VisitBinary` and the duplicate visiting of its children (left and right).

This can lead to a very long runtime even for medium size expressions. In the attached test the optimization of the 27 trivial comparisons (`e.Id == 1 || e.Id == 2 || ... || e.Id == 27`) takes more than 20 seconds on my machine. Every additional comparison doubles the runtime. So having about 100 trivial expressions would take several trillion years to optimize.

The solution is to _not_ call `base.VisitBinary`, because this would visit the two children _again_, which was already done in our override in the beginning. Instead we just construct a new binary expression like `base.VisitBinary` does, but using the already visited variables `left` and `right`.