### PR TITLE
Add repro test and fix for abstract method override calling base property in polymorphic base query

### DIFF
--- a/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Abstracts/Animal.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Abstracts/Animal.cs
@@ -4,5 +4,8 @@
     {
         [Computed]
         public abstract bool IsPet { get; }
+
+        [Computed]
+        public abstract string SpeciesAndAge();
     }
 }

--- a/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Abstracts/Dog.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Abstracts/Dog.cs
@@ -10,5 +10,8 @@ namespace DelegateDecompiler.EntityFramework.Tests.EfItems.Abstracts
     {
         public override string Species => "Canis lupus";
         public override bool IsPet => true;
+
+        [Computed]
+        public override string SpeciesAndAge() => string.Concat(Species, " : ", Age);
     }
 }

--- a/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Abstracts/HoneyBee.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/EfItems/Abstracts/HoneyBee.cs
@@ -5,5 +5,8 @@
         public override string Species => "Apis mellifera";
 
         public override bool IsPet => false;
+
+        [Computed]
+        public override string SpeciesAndAge() => string.Concat(Species, " : ", Age);
     }
 }

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test01Select.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test01Select.cs
@@ -241,6 +241,9 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
         {
             using (var env = new MethodEnvironment(classEnv))
             {
+                //SETUP
+                var linq = env.Db.LivingBeeing.OfType<Animal>().ToList().Select(p => p.SpeciesAndAge()).ToList();
+
                 //ATTEMPT
                 env.AboutToUseDelegateDecompiler();
                 var dd = env.Db.LivingBeeing.OfType<Animal>().Select(p => p.SpeciesAndAge())
@@ -250,7 +253,7 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
                     .ToList();
 
                 //VERIFY
-                Assert.That(dd, Is.Not.Empty);
+                env.CompareAndLogList(linq, dd);
             }
         }
 

--- a/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test01Select.cs
+++ b/src/DelegateDecompiler.EntityFramework.Tests/TestGroup05BasicFeatures/Test01Select.cs
@@ -235,6 +235,25 @@ namespace DelegateDecompiler.EntityFramework.Tests.TestGroup05BasicFeatures
             }
         }
 
+
+        [Test]
+        public void TestSelectAbstractMethodImplementedInDerivedCallingBasePropertyFromBaseType()
+        {
+            using (var env = new MethodEnvironment(classEnv))
+            {
+                //ATTEMPT
+                env.AboutToUseDelegateDecompiler();
+                var dd = env.Db.LivingBeeing.OfType<Animal>().Select(p => p.SpeciesAndAge())
+#if NO_AUTO_DECOMPILE
+                    .Decompile()
+#endif
+                    .ToList();
+
+                //VERIFY
+                Assert.That(dd, Is.Not.Empty);
+            }
+        }
+
         [Test]
         public void TestSelectSelectMany()
         {


### PR DESCRIPTION
Hi hazzik,

This PR adds a minimal repro test for a bug I’m hitting when using DelegateDecompiler with EF in a polymorphic query scenario.

# What the test covers

* There is an abstract base class with a base property.
* The base class declares an abstract method.
* A derived/concrete class overrides that abstract method.
* The override reads the base property.
* The query is executed from the base set/type (i.e. we keep the base type in the query, *not* using OfType() towards the actual concrete type / explicit casting).

In this setup, projecting the abstract method (implemented in the derived type) causes the query translation/decompilation to fail as I get the following error:

```
Message: 
System.NotSupportedException : Unable to cast the type 'DelegateDecompiler.EntityFramework.Tests.EfItems.Abstracts.Animal' to type 'DelegateDecompiler.EntityFramework.Tests.EfItems.Abstracts.HoneyBee'. LINQ to Entities only supports casting EDM primitive or enumeration types.

Stack Trace: 
ExpressionConverter.ValidateAndAdjustCastTypes(TypeUsage toType, TypeUsage fromType, Type toClrType, Type fromClrType)
ExpressionConverter.GetCastTargetType(TypeUsage fromType, Type toClrType, Type fromClrType, Boolean preserveCastForDateTime)
ExpressionConverter.CreateCastExpression(DbExpression source, Type toClrType, Type fromClrType)
ExpressionConverter.TranslateExpression(Expression linq)
MemberAccessTranslator.TypedTranslate(ExpressionConverter parent, MemberExpression linq)
ExpressionConverter.TranslateExpression(Expression linq)
StringTranslatorUtil.ConvertToString(ExpressionConverter parent, Expression linqExpression)
WhereSelectArrayIterator`2.MoveNext()
Buffer`1.ctor(IEnumerable`1 source)
Enumerable.ToArray[TSource](IEnumerable`1 source)
<11 more frames...>
<>c__DisplayClass41_0.<GetResults>b__1()
ObjectContext.ExecuteInTransaction[T](Func`1 func, IDbExecutionStrategy executionStrategy, Boolean startLocalTransaction, Boolean releaseConnectionOnSuccess)
<>c__DisplayClass41_0.<GetResults>b__0()
DefaultSqlExecutionStrategy.Execute[TResult](Func`1 operation)
ObjectQuery`1.GetResults(Nullable`1 forMergeOption)
IEnumerable<T>.GetEnumerator>b__31_0()
LazyEnumerator`1.MoveNext()
List`1.ctor(IEnumerable`1 collection)
Enumerable.ToList[TSource](IEnumerable`1 source)
Test01Select.TestSelectAbstractMethodImplementedInDerivedCallingBasePropertyFromBaseType() line 246
```

When I look deeper, it seems like it tries to cast LivingBeein/Animal to Dog/HoneyBee when retrieving the value of the base class, which fails within Entity Framework and shouldn't even be needed considering (in my case) I'm using TPH.

I’m opening this PR primarily to contribute a repeatable, automated repro that documents the exact scenario and prevent possible regressions once a fix is found.

If someone familiar with the decompiler/EF translation path can point me at where this cast is being introduced, or provide a fix, I’d really appreciate the help/guidance.